### PR TITLE
Added the exclusion of archived repositories #270

### DIFF
--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -43,7 +43,11 @@ export const onCreateNode = ({
   cache,
   createNodeId,
 }) => {
-  if (node.internal.type === REPOSITORY_NODE_TYPE && !!node.valid) {
+  if (
+    node.internal.type === REPOSITORY_NODE_TYPE &&
+    !!node.valid &&
+    !node.archived
+  ) {
     node.week_stargazers_count = computeTrendingStargazersCount(
       node.stargazers_count_history,
       node.github_created_at,
@@ -106,17 +110,20 @@ export const onPostBootstrap = async () => {
 
 const createRepositoryPages = (repositories, createPage) => {
   repositories.forEach(repository => {
-    const ownerName = repository.owner ? repository.owner.name : "";
-    const { name } = repository;
-    const repositoryPath = URLify(`${ownerName}/${name}`);
-    createPage({
-      path: repositoryPath,
-      component: path.resolve("./src/templates/repository/index.jsx"),
-      context: {
-        ownerName,
-        name,
-      },
-    });
+    const { archived } = repository;
+    if (!archived) {
+      const ownerName = repository.owner ? repository.owner.name : "";
+      const { name } = repository;
+      const repositoryPath = URLify(`${ownerName}/${name}`);
+      createPage({
+        path: repositoryPath,
+        component: path.resolve("./src/templates/repository/index.jsx"),
+        context: {
+          ownerName,
+          name,
+        },
+      });
+    }
   });
 };
 
@@ -163,10 +170,11 @@ const createSearchIndex = async repositories => {
 
 const repositoriesQuery = `
   {
-    allMongodbColorschemesRepositories(filter: {valid: { eq: true }, image_urls: { ne: "" }}) {
+    allMongodbColorschemesRepositories(filter: {valid: { eq: true },archived: {ne: true}, image_urls: { ne: "" }}) {
       nodes {
         id
         name
+        archived
         owner {
           name
         }

--- a/gatsby-node.esm.js
+++ b/gatsby-node.esm.js
@@ -110,20 +110,17 @@ export const onPostBootstrap = async () => {
 
 const createRepositoryPages = (repositories, createPage) => {
   repositories.forEach(repository => {
-    const { archived } = repository;
-    if (!archived) {
-      const ownerName = repository.owner ? repository.owner.name : "";
-      const { name } = repository;
-      const repositoryPath = URLify(`${ownerName}/${name}`);
-      createPage({
-        path: repositoryPath,
-        component: path.resolve("./src/templates/repository/index.jsx"),
-        context: {
-          ownerName,
-          name,
-        },
-      });
-    }
+    const ownerName = repository.owner ? repository.owner.name : "";
+    const { name } = repository;
+    const repositoryPath = URLify(`${ownerName}/${name}`);
+    createPage({
+      path: repositoryPath,
+      component: path.resolve("./src/templates/repository/index.jsx"),
+      context: {
+        ownerName,
+        name,
+      },
+    });
   });
 };
 
@@ -174,7 +171,6 @@ const repositoriesQuery = `
       nodes {
         id
         name
-        archived
         owner {
           name
         }

--- a/src/templates/repositories/index.jsx
+++ b/src/templates/repositories/index.jsx
@@ -163,7 +163,11 @@ export const query = graphql`
     $sortOrder: [SortOrderEnum]!
   ) {
     repositoriesData: allMongodbColorschemesRepositories(
-      filter: { valid: { eq: true }, image_urls: { ne: "" } }
+      filter: {
+        valid: { eq: true }
+        archived: { ne: true }
+        image_urls: { ne: "" }
+      }
       sort: { fields: $sortField, order: $sortOrder }
       limit: $limit
       skip: $skip


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Exclude archived repositories , testing it with the recent given seed, by rivisitating filter of queries and also by adding additional controls in javascript code.

## Related issue

Closes #270 

## QA Instructions

With the recent seed we could find out this repository having archived variable setted to true:
![image](https://user-images.githubusercontent.com/45283261/96517228-dbe44100-1268-11eb-9d3f-16e7789bb29f.png)

By adding some controls and expanding the filter options of queries with
![image](https://user-images.githubusercontent.com/45283261/96517349-151cb100-1269-11eb-89fc-116c633881e2.png)
(the option of not equal was chosen to allow the pages with archived variable setted to null to be also builded)

To verify if my changes works just browse between two pages and see how you cannot locate "Hypsteria" repository
(I also excluded the creation of path URL to archived repositories)

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [x] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
