### PR TITLE
Replace gatsby-image with gatsby-plugin-image

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,6 +23,7 @@ module.exports = {
     "gatsby-plugin-sitemap",
     "gatsby-transformer-sharp",
     "gatsby-plugin-preact",
+    "gatsby-plugin-image",
     {
       resolve: "gatsby-plugin-robots-txt",
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5250,6 +5250,11 @@
         }
       }
     },
+    "babel-jsx-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-jsx-utils/-/babel-jsx-utils-1.0.1.tgz",
+      "integrity": "sha512-Qph/atlQiSvfmkoIZ9VA+t8dA0ex2TwL37rkhLT9YLJdhaTMZ2HSM2QGzbqjLWanKA+I3wRQJjjhtuIEgesuLw=="
+    },
     "babel-loader": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -11234,16 +11239,6 @@
         "@babel/runtime": "^7.11.2"
       }
     },
-    "gatsby-image": {
-      "version": "2.4.21",
-      "resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.4.21.tgz",
-      "integrity": "sha512-OrXJkCR7z5SYkBumjPyoZbV9RqQQZsIvO1JM4WyzIMKcOCKhpOFChCahLXdi0Ggnw0yVk58CAFYGWUjNeVdUpQ==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "object-fit-images": "^3.2.4",
-        "prop-types": "^15.7.2"
-      }
-    },
     "gatsby-interface": {
       "version": "0.0.193",
       "resolved": "https://registry.npmjs.org/gatsby-interface/-/gatsby-interface-0.0.193.tgz",
@@ -11303,6 +11298,21 @@
         "glob": "^7.1.6",
         "lodash": "^4.17.20",
         "micromatch": "^4.0.2"
+      }
+    },
+    "gatsby-plugin-image": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-0.0.4.tgz",
+      "integrity": "sha512-QDf3TZtKgOQA4VJvRDKKyqSXY3nX4bzgJWRgFbTIFfbnuugW2QYNHoXvFF+WT0KwfuQrT+foquU2kcvJaN7cTg==",
+      "requires": {
+        "@babel/parser": "^7.8.7",
+        "@babel/traverse": "^7.8.6",
+        "babel-jsx-utils": "^1.0.1",
+        "babel-plugin-remove-graphql-queries": "^2.9.19",
+        "chokidar": "^3.4.2",
+        "fs-extra": "^8.1.0",
+        "gatsby-core-utils": "^1.3.20",
+        "prop-types": "^15.7.2"
       }
     },
     "gatsby-plugin-manifest": {
@@ -19754,11 +19764,6 @@
           }
         }
       }
-    },
-    "object-fit-images": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
-      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
     },
     "object-hash": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "esm": "^3.2.25",
     "gatsby": "^2.24.85",
     "gatsby-cli": "^2.12.111",
-    "gatsby-image": "^2.4.21",
+    "gatsby-plugin-image": "0.0.4",
     "gatsby-plugin-manifest": "^2.4.34",
     "gatsby-plugin-preact": "^4.0.16",
     "gatsby-plugin-react-helmet": "^3.3.14",

--- a/src/components/card/index.jsx
+++ b/src/components/card/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "gatsby";
-import Img from "gatsby-image";
+import { GatsbyImage } from "gatsby-plugin-image/compat";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
@@ -47,7 +47,7 @@ const Card = ({ repository, linkState, onLinkClick, className }) => {
         <div className="card__image">
           {!!fluidImage &&
             (fluidImage.base64 ? (
-              <Img
+              <GatsbyImage
                 fluid={fluidImage}
                 alt={`${ownerName} ${name}`}
                 imgStyle={imageStyle}

--- a/src/components/zoomableImage/index.jsx
+++ b/src/components/zoomableImage/index.jsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import classnames from "classnames";
-import Img from "gatsby-image";
+import { GatsbyImage } from "gatsby-plugin-image/compat";
 import PropTypes from "prop-types";
 
 import { KEYS } from "src/constants";
@@ -13,7 +13,7 @@ const ZoomableImage = ({ image, className, ...inputArgs }) => {
   if (!image.childImageSharp?.fluid) return null;
 
   const renderedImage = (
-    <Img
+    <GatsbyImage
       fluid={image.childImageSharp.fluid}
       alt="zoomable"
       className="zoomable__image"


### PR DESCRIPTION
## Type of PR

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Replace gatsby-image with gatsby-plugin-image

## Related issue

feat: Try out Gatsby's new image plugin #252

## QA Instructions

When I compare the style of the images at https://vimcolorschemes.com/ with my build, looks different.
Is this right??

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
