### PR TITLE
feat: Disable pointer events when using keyboard

### DIFF
--- a/src/components/page/index.tsx
+++ b/src/components/page/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import useNavigation from '@/hooks/navigation';
+import usePointerEvents from '@/hooks/pointerEvents';
 
 import Footer from '@/components/footer';
 import Header from '@/components/header';
@@ -16,6 +17,7 @@ interface Props {
 
 function Page({ isHome, children, className }: Props) {
   useNavigation();
+  usePointerEvents();
 
   return (
     <>

--- a/src/hooks/__tests__/navigation.test.ts
+++ b/src/hooks/__tests__/navigation.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 
+import Keys from '@/lib/keys';
 import useNavigation from '@/hooks/navigation';
 
 /*
@@ -28,7 +29,9 @@ describe('useNavigation', () => {
 
     renderHook(() => useNavigation());
 
-    fireEvent.keyDown(global.document.documentElement, { key: 'j' });
+    fireEvent.keyDown(global.document.documentElement, {
+      key: Keys.Navigation.Down,
+    });
 
     expect(global.document.activeElement).toBe(first);
   });
@@ -47,11 +50,15 @@ describe('useNavigation', () => {
 
     renderHook(() => useNavigation());
 
-    fireEvent.keyDown(global.document.documentElement, { key: 'j' });
+    fireEvent.keyDown(global.document.documentElement, {
+      key: Keys.Navigation.Down,
+    });
 
     expect(global.document.activeElement).toBe(first);
 
-    fireEvent.keyDown(global.document.documentElement, { key: 'j' });
+    fireEvent.keyDown(global.document.documentElement, {
+      key: Keys.Navigation.Down,
+    });
 
     expect(global.document.activeElement).toBe(second);
   });

--- a/src/hooks/__tests__/pointerEvents.test.ts
+++ b/src/hooks/__tests__/pointerEvents.test.ts
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent } from '@testing-library/react';
+
+import usePointerEvents from '@/hooks/pointerEvents';
+import Keys from '@/lib/keys';
+
+describe('usePointerEvents', () => {
+  test('should disable pointer events when a navigation shorcut is pressed', () => {
+    renderHook(() => usePointerEvents());
+
+    fireEvent.keyDown(document, { key: Keys.Navigation.Down });
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  test('should enable again pointer events after the mouse has moved', () => {
+    renderHook(() => usePointerEvents());
+
+    fireEvent.keyDown(document, { key: Keys.Navigation.Down });
+
+    expect(document.body.style.pointerEvents).toBe('none');
+
+    fireEvent.mouseMove(document);
+
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+});

--- a/src/hooks/navigation.ts
+++ b/src/hooks/navigation.ts
@@ -1,5 +1,6 @@
 import DOMHelper from '@/helpers/dom';
 import useShortcut from '@/hooks/shortcut';
+import Keys from '@/lib/keys';
 
 enum Direction {
   Left = 'left',
@@ -59,10 +60,10 @@ function useNavigation() {
   }
 
   useShortcut({
-    h: event => go(Direction.Left, event),
-    j: event => go(Direction.Down, event),
-    k: event => go(Direction.Up, event),
-    l: event => go(Direction.Right, event),
+    [Keys.Navigation.Left]: event => go(Direction.Left, event),
+    [Keys.Navigation.Down]: event => go(Direction.Down, event),
+    [Keys.Navigation.Up]: event => go(Direction.Up, event),
+    [Keys.Navigation.Right]: event => go(Direction.Right, event),
   });
 }
 

--- a/src/hooks/pointerEvents.ts
+++ b/src/hooks/pointerEvents.ts
@@ -1,0 +1,42 @@
+import Keys from '@/lib/keys';
+import useEvent from '@/hooks/event';
+
+/**
+ * Disable pointer events when the user uses the keynoard
+ * Enables them again after the mouse moves
+ */
+function usePointerEvents() {
+  function eventListener(event: KeyboardEvent) {
+    if (!Object.values(Keys.Navigation).includes(event.key)) {
+      return;
+    }
+
+    disablePointerEvents();
+  }
+
+  useEvent('keydown', eventListener);
+}
+
+function disablePointerEvents() {
+  if (document.body.style.pointerEvents === 'none') {
+    return;
+  }
+
+  document.body.style.pointerEvents = 'none';
+
+  window.addEventListener('mousemove', activatePointerEvents);
+  window.addEventListener('touchstart', activatePointerEvents);
+}
+
+function activatePointerEvents() {
+  if (document.body.style.pointerEvents === '') {
+    return;
+  }
+
+  document.body.style.pointerEvents = '';
+
+  window.removeEventListener('mousemove', activatePointerEvents);
+  window.removeEventListener('touchstart', activatePointerEvents);
+}
+
+export default usePointerEvents;

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -1,9 +1,20 @@
-enum Keys {
-  Background = 'b',
-  Escape = 'Escape',
-  Search = '/',
-  Submit = 'Enter',
-  Undo = 'u',
-}
+const Keys = {
+  Background: 'b',
+  Escape: 'Escape',
+  Search: '/',
+  Submit: 'Enter',
+  Undo: 'u',
+  Navigation: {
+    Up: 'k',
+    Right: 'l',
+    Down: 'j',
+    Left: 'h',
+    ArrowUp: 'k',
+    ArrowRight: 'l',
+    ArrowDown: 'j',
+    ArrowLeft: 'h',
+    Tab: 'Tab',
+  },
+};
 
 export default Keys;


### PR DESCRIPTION
## Type of PR

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

 * Disable pointer events when the user uses the keynoard
 * Enables them again after the mouse moves

## Related issue

Closes #389 

## QA Instructions

- Move mouse
- Notice the mouse moving
- Use navigation keyboard shortcut like `j`
- Notice the mouse disappears
- Notice the mouse doesn't trigger hover styles
- Move the mouse
- Notice the mouse and hover styles work like before

## Added tests?

- [x] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [x] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [ ] no
