### PR TITLE
fix: Prevent code font from glitching in Safari

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,5 @@
 import 'typeface-source-sans-pro';
-import 'typeface-jetbrains-mono';
+import 'typeface-ubuntu-mono';
 
 export function onPreRouteUpdate() {
   // Adds a previousPath property that is available on all pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -18406,15 +18406,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typeface-jetbrains-mono": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/typeface-jetbrains-mono/-/typeface-jetbrains-mono-2.0.1.tgz",
-      "integrity": "sha512-r5ehb53K0x7VWFkk35jD1Hpnk09qm26wJM7H+mclj+eXX35IAoDC7x1NDDCKy0kpyvLo7xoEEY3d9Slj1Ar8vQ=="
-    },
     "typeface-source-sans-pro": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/typeface-source-sans-pro/-/typeface-source-sans-pro-1.1.13.tgz",
       "integrity": "sha512-eCczLh0FYByjVoMxZVDfSSTI8A6qJOBJftgWBVJL63AuemQTTvMU8DEk6ud/TQhkbIwWZ3A7ll/NfS9yI0lIrQ=="
+    },
+    "typeface-ubuntu-mono": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/typeface-ubuntu-mono/-/typeface-ubuntu-mono-1.1.13.tgz",
+      "integrity": "sha512-UBKNVxZukk2B+LnxxN0fwuKobwbO2u9BKyFQA07ux9pdxoKw7kUgKNXnxYH3utcvrge7wtoccnzyWwiclOWxow=="
     },
     "typescript": {
       "version": "4.4.4",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "spatial-navigation-polyfill": "^1.3.1",
     "swr": "^1.0.1",
     "ts-node": "^10.4.0",
-    "typeface-jetbrains-mono": "^2.0.1",
-    "typeface-source-sans-pro": "^1.1.13"
+    "typeface-source-sans-pro": "^1.1.13",
+    "typeface-ubuntu-mono": "^1.1.13"
   },
   "devDependencies": {
     "@elastic/elasticsearch": "^7.15.0",

--- a/src/components/preview/code/index.scss
+++ b/src/components/preview/code/index.scss
@@ -1,3 +1,5 @@
 .code {
-  line-height: 1.3;
+  font-family: var(--code-font-family);
+  font-size: var(--large-font-size);
+  line-height: 1.25;
 }

--- a/src/components/preview/vimRC/index.scss
+++ b/src/components/preview/vimRC/index.scss
@@ -6,11 +6,10 @@
 button.vimrc__button {
   @include button-reset;
 
+  font-size: calc(var(--large-font-size) - 1px);
   cursor: pointer;
-
   padding: 0 var(--smallest-space);
   margin: calc(var(--smallest-space) * -1);
-
   display: inline-flex;
   align-items: center;
   column-gap: 0.1rem;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -31,6 +31,7 @@ body {
   font-size: var(--standard-font-size);
   line-height: var(--line-height);
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 * {
@@ -49,11 +50,6 @@ b {
 
 button {
   font-size: var(--standard-font-size);
-}
-
-pre,
-code {
-  font-family: var(--code-font-family);
 }
 
 .subtitle {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -53,7 +53,7 @@ body {
   --largest-space: calc(var(--large-space) * 2);
 
   --standard-font-family: 'Source Sans Pro', sans-serif;
-  --code-font-family: 'Jetbrains Mono', monospace;
+  --code-font-family: 'Ubuntu Mono', monospace;
   --line-height: 1.5;
 
   --standard-font-size: 16px;


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Fixes font in Safari

## Related issue

Closes #405 

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
