### PR TITLE
fix: Remove focus indicator on code blocks on iOS

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -73,3 +73,7 @@ button {
     padding: 0 var(--large-space);
   }
 }
+
+code {
+  outline: 0;
+}


### PR DESCRIPTION
## Type of PR
- [ ] Bug Fix
https://github.com/vimcolorschemes/vimcolorschemes/issues/407

## Description

remove outline css from code tag