### PR TITLE
fix: Wait for colors to be loaded before generating preview image

### DIFF
--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -19,6 +19,8 @@ function Preview({ vimColorSchemes, className }: Props) {
   const defaultVimColorScheme = vimColorSchemes[0];
   const [index, setIndex] = useState<number>(0);
 
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
   const [background, setBackground] = useState<Background>(
     defaultVimColorScheme.defaultBackground,
   );
@@ -47,6 +49,8 @@ function Preview({ vimColorSchemes, className }: Props) {
     groups.forEach(group => {
       preview.current?.style.setProperty(`--vim-${group.name}`, group.hexCode);
     });
+
+    setIsLoading(false);
   }, [background, vimColorScheme, preview]);
 
   function changeVimColorScheme() {
@@ -81,6 +85,7 @@ function Preview({ vimColorSchemes, className }: Props) {
       className={classnames('preview', className, {
         'preview--light': background === Background.Light,
         'preview--dark': background === Background.Dark,
+        'preview--loaded': !isLoading,
       })}
       ref={preview}
     >

--- a/src/gatsby/preview.ts
+++ b/src/gatsby/preview.ts
@@ -53,6 +53,8 @@ async function generatePreviewImages(
       fs.mkdirSync(previewDirectory, { recursive: true });
     }
 
+    await page.waitForSelector('.preview.preview--loaded');
+
     await page.screenshot({
       path: previewPath,
       clip: {
@@ -63,7 +65,7 @@ async function generatePreviewImages(
       },
     });
 
-    await page.close()
+    await page.close();
   }
 
   await browser.close();


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

During preview image generation, wait for colors to be loaded on to the template before taking a screenshot with puppeteer.

## Related issue

Closes #415 

## QA Instructions

1. set `GATSBY_ENABLE_GENERATE_PREVIEW_IMAGES` to `true` in `.env`
2. run `npm run build`
3. open the `./public/previews` directory
4. check out the generated images

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
