### PR TITLE
test: Run E2E tests only on main branch pushes

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,21 +1,10 @@
-name: Run tests
+name: Run E2E tests
 
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
-  unit_tests:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: npm ci
-    - name: Run unit tests
-      run: npm run test.unit
   e2e_tests:
     name: Run E2E tests on Chrome
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,18 @@
+name: Run unit tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit_tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm ci
+    - name: Run unit tests
+      run: npm run test.unit


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [x] Tests

## Description

Do not run E2E on PRs, as for them to work, we need to open secrets to fork PRs, which is a security hole.