### PR TITLE
feat: Display all color scheme variations in preview image

### DIFF
--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -15,12 +15,11 @@ interface Props {
   vimColorSchemes: VimColorScheme[];
   title?: React.ReactNode;
   className?: string;
+  onLoad?: () => void;
 }
 
-function Preview({ vimColorSchemes, title, className }: Props) {
+function Preview({ vimColorSchemes, title, className, onLoad }: Props) {
   const [index, setIndex] = useState<number>(0);
-
-  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const [background, setBackground] = useState<Background>(
     vimColorSchemes[0].defaultBackground,
@@ -59,7 +58,9 @@ function Preview({ vimColorSchemes, title, className }: Props) {
       preview.current?.style.setProperty(`--vim-${group.name}`, group.hexCode);
     });
 
-    setIsLoading(false);
+    if (onLoad) {
+      onLoad();
+    }
   }, [background, vimColorScheme, preview]);
 
   function changeVimColorScheme() {
@@ -94,7 +95,6 @@ function Preview({ vimColorSchemes, title, className }: Props) {
       className={classnames('preview', className, {
         'preview--light': background === Background.Light,
         'preview--dark': background === Background.Dark,
-        'preview--loaded': !isLoading,
       })}
       ref={preview}
     >

--- a/src/gatsby/preview.ts
+++ b/src/gatsby/preview.ts
@@ -54,7 +54,7 @@ async function generatePreviewImages(
       fs.mkdirSync(previewDirectory, { recursive: true });
     }
 
-    await page.waitForSelector('.preview.preview--loaded');
+    await page.waitForSelector('.preview-page.preview-page--loaded');
 
     await page.screenshot({
       path: previewPath,

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -83,8 +83,7 @@ export class Repository {
   }
 
   get title(): string {
-    const name = this.flattenedVimColorSchemes[0]?.name || this.name;
-    return `${name} vim color scheme, by ${this.owner.name}`;
+    return `${this.name}, by ${this.owner.name}`;
   }
 
   get previewRoute(): string {

--- a/src/templates/preview/index.scss
+++ b/src/templates/preview/index.scss
@@ -2,12 +2,21 @@
   width: 1200px !important;
   height: 627px !important;
 
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  position: relative;
+}
+
+.preview-page__preview-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .preview-page__preview {
   font-size: var(--large-font-size);
   box-shadow: 0 22px 70px 4px rgba(0, 0, 0, 0.56);
+}
+
+.preview-page--gallery .preview-page__preview {
+  font-size: var(--standard-font-size);
 }

--- a/src/templates/preview/index.tsx
+++ b/src/templates/preview/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { graphql } from 'gatsby';
+import classnames from 'classnames';
 
 import { APIRepository } from '@/models/api';
 import { Repository } from '@/models/repository';
@@ -7,6 +8,9 @@ import { Repository } from '@/models/repository';
 import Preview from '@/components/preview';
 
 import './index.scss';
+
+// Space in % between 2 previews when there are multiple vim color schemes
+const PREVIEW_SPACING = 10;
 
 interface Props {
   data: {
@@ -17,12 +21,47 @@ interface Props {
 function PreviewPage({ data: { apiRepository } }: Props) {
   const repository = new Repository(apiRepository);
 
+  const vimColorSchemes = useMemo(
+    () => repository.flattenedVimColorSchemes,
+    [repository],
+  );
+
+  const previewStartingPosition = useMemo(() => {
+    const count = Math.min(vimColorSchemes.length - 1, 3);
+    return 50 - (PREVIEW_SPACING / 2) * count;
+  }, [vimColorSchemes.length]);
+
   return (
-    <div className="preview-page">
-      <Preview
-        vimColorSchemes={[repository.defaultVimColorScheme]}
-        className="preview-page__preview"
-      />
+    <div
+      className={classnames('preview-page', {
+        'preview-page--gallery': vimColorSchemes.length > 1,
+      })}
+    >
+      {repository.flattenedVimColorSchemes.map((vimColorScheme, index) => {
+        const offset = index * PREVIEW_SPACING;
+        const position = `${previewStartingPosition + offset}%`;
+        const top = position;
+        const left = position;
+
+        const zIndex = -index;
+
+        return (
+          <div
+            className="preview-page__preview-container"
+            style={{
+              top,
+              left,
+              zIndex,
+            }}
+            key={vimColorScheme.key}
+          >
+            <Preview
+              vimColorSchemes={[vimColorScheme]}
+              className="preview-page__preview"
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/templates/preview/index.tsx
+++ b/src/templates/preview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { graphql } from 'gatsby';
 import classnames from 'classnames';
 
@@ -19,6 +19,8 @@ interface Props {
 }
 
 function PreviewPage({ data: { apiRepository } }: Props) {
+  const [loadState, setLoadState] = useState<Record<string, boolean>>({});
+
   const repository = new Repository(apiRepository);
 
   const vimColorSchemes = useMemo(
@@ -35,6 +37,8 @@ function PreviewPage({ data: { apiRepository } }: Props) {
     <div
       className={classnames('preview-page', {
         'preview-page--gallery': vimColorSchemes.length > 1,
+        'preview-page--loaded':
+          vimColorSchemes.length === Object.keys(loadState).length,
       })}
     >
       {repository.flattenedVimColorSchemes.map((vimColorScheme, index) => {
@@ -58,6 +62,16 @@ function PreviewPage({ data: { apiRepository } }: Props) {
             <Preview
               vimColorSchemes={[vimColorScheme]}
               className="preview-page__preview"
+              onLoad={() => {
+                if (loadState[vimColorScheme.key]) {
+                  return;
+                }
+
+                setLoadState(state => ({
+                  ...state,
+                  [vimColorScheme.key]: true,
+                }));
+              }}
             />
           </div>
         );


### PR DESCRIPTION
## Type of PR

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Display all variations in a nice gallery in the SEO preview image

## QA Instructions

1. Set `GATSBY_ENABLE_GENERATE_PREVIEW_IMAGES` to `true` in `.env`
2. `npm run build`
3. See `public/previews` directory

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
