### PR TITLE
feat: Temporarily hide neovim color schemes in queries

### DIFF
--- a/src/gatsby/node.ts
+++ b/src/gatsby/node.ts
@@ -161,7 +161,12 @@ const repositoriesQuery = `
     filter: {
       updateValid: { eq: true }
       generateValid: { eq: true }
-      vimColorSchemes: { elemMatch: { valid: { eq: true } } }
+      vimColorSchemes: {
+        elemMatch: {
+          valid: { eq: true }
+          isLua: { ne: true }
+        }
+      }
     }
   ) {
     apiRepositories: nodes {

--- a/src/templates/repositories/index.tsx
+++ b/src/templates/repositories/index.tsx
@@ -128,7 +128,11 @@ export const query = graphql`
         updateValid: { eq: true }
         generateValid: { eq: true }
         vimColorSchemes: {
-          elemMatch: { valid: { eq: true }, backgrounds: { in: $filters } }
+          elemMatch: {
+            valid: { eq: true }
+            backgrounds: { in: $filters }
+            isLua: { ne: true }
+          }
         }
       }
       sort: { fields: $sortProperty, order: $sortOrder }


### PR DESCRIPTION
## Type of PR

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Hides neovim color schemes until the UI is ready to receive them

## Related issue

#727 #726 