### PR TITLE
feat: Add visual cue for vim vs. lua color schemes

### DIFF
--- a/src/components/meta/index.scss
+++ b/src/components/meta/index.scss
@@ -32,10 +32,24 @@ $row-height: 1.25rem;
 
 .meta-footer {
   display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  column-gap: var(--standard-space);
+}
+
+.meta-footer__column {
+  display: flex;
   flex-direction: column;
   row-gap: var(--smallest-space);
 }
 
 .meta-footer__row {
   line-height: $row-height;
+}
+
+.meta-footer__pills {
+  display: flex;
+  align-items: center;
+  column-gap: var(--smallest-space);
 }

--- a/src/components/meta/index.tsx
+++ b/src/components/meta/index.tsx
@@ -6,6 +6,7 @@ import { Repository } from '@/models/repository';
 
 import IconStar from '@/components/icons/star';
 import IconTrendingUp from '@/components/icons/trendingUp';
+import Pill from '@/components/pill';
 
 import './index.scss';
 
@@ -58,22 +59,28 @@ export function MetaDescription({ repository, className }: Props) {
 export function MetaFooter({ repository, className }: Props) {
   return (
     <footer className={classnames('meta-footer', className)}>
-      <p className="meta-footer__row">
-        Created{' '}
-        <b>
-          <time dateTime={repository.githubCreatedAt}>
-            {DateHelper.fromNow(repository.githubCreatedAt)}
-          </time>
-        </b>
-      </p>
-      <p className="meta-footer__row">
-        Last commit{' '}
-        <b>
-          <time dateTime={repository.lastCommitAt}>
-            {DateHelper.fromNow(repository.lastCommitAt)}
-          </time>
-        </b>
-      </p>
+      <div className="meta-footer__column">
+        <p className="meta-footer__row">
+          Created{' '}
+          <b>
+            <time dateTime={repository.githubCreatedAt}>
+              {DateHelper.fromNow(repository.githubCreatedAt)}
+            </time>
+          </b>
+        </p>
+        <p className="meta-footer__row">
+          Last commit{' '}
+          <b>
+            <time dateTime={repository.lastCommitAt}>
+              {DateHelper.fromNow(repository.lastCommitAt)}
+            </time>
+          </b>
+        </p>
+      </div>
+      <div className="meta-footer__pills">
+        {repository.isVim && <Pill>vim</Pill>}
+        {repository.isLua && <Pill>lua</Pill>}
+      </div>
     </footer>
   );
 }

--- a/src/components/pill/index.scss
+++ b/src/components/pill/index.scss
@@ -1,0 +1,11 @@
+.pill {
+  display: inline-block;
+  color: var(--foreground);
+  border: 1px solid var(--focus-border);
+  height: 1rem;
+  border-radius: var(--standard-border-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--smallest-space) var(--small-space);
+}

--- a/src/components/pill/index.tsx
+++ b/src/components/pill/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import './index.scss';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+function Pill({ children }: Props) {
+  return <div className="pill">{children}</div>;
+}
+
+export default Pill;

--- a/src/components/preview/index.scss
+++ b/src/components/preview/index.scss
@@ -54,6 +54,17 @@ $header-button-colors: (
   }
 }
 
+.preview__header-file-name {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.preview__header-type {
+  position: absolute;
+  right: var(--small-space);
+}
+
 .preview > * {
   margin: 0;
 }

--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -102,7 +102,12 @@ function Preview({ vimColorSchemes, title, className, onLoad }: Props) {
         <div />
         <div />
         <div />
-        <code data-ignore-a11y>{title || vimColorScheme.name}</code>
+        <code data-ignore-a11y className="preview__header-file-name">
+          {title || vimColorScheme.name}
+        </code>
+        <code data-ignore-a11y className="preview__header-type">
+          {vimColorScheme.isLua ? 'lua' : 'vim'}
+        </code>
       </header>
       <VimRC
         vimColorScheme={vimColorScheme}

--- a/src/gatsby/node.ts
+++ b/src/gatsby/node.ts
@@ -177,6 +177,8 @@ const repositoriesQuery = `
       lastCommitAt
       githubURL
       weekStargazersCount
+      isVim
+      isLua
       owner {
         name
       }
@@ -184,6 +186,7 @@ const repositoriesQuery = `
         name
         valid
         backgrounds
+        isLua
         data {
           light {
             name

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -11,6 +11,8 @@ export interface APIRepository {
   githubURL: string;
   stargazersCount: number;
   weekStargazersCount: number;
+  isVim: boolean;
+  isLua: boolean;
   vimColorSchemes: APIVimColorScheme[] | null;
 }
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -20,6 +20,7 @@ export interface APIVimColorScheme {
   name: string;
   valid: boolean;
   data: APIVimColorSchemeData | null;
+  isLua: boolean;
   backgrounds: Background[];
 }
 

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -28,8 +28,12 @@ export class Repository {
     this.githubURL = apiRepository.githubURL;
     this.stargazersCount = apiRepository.stargazersCount;
     this.weekStargazersCount = apiRepository.weekStargazersCount;
-    this.isVim = apiRepository.isVim;
-    this.isLua = apiRepository.isLua;
+
+    this.isVim = !!apiRepository.isVim;
+    this.isLua = !!apiRepository.isLua;
+    if (!this.isVim && !this.isLua) {
+      this.isVim = true;
+    }
 
     let defaultBackground = Background.Light;
 

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -14,6 +14,8 @@ export class Repository {
   githubURL: string;
   stargazersCount: number;
   weekStargazersCount: number;
+  isVim: boolean;
+  isLua: boolean;
   vimColorSchemes: VimColorScheme[];
   private _defaultBackground: Background;
 
@@ -26,6 +28,8 @@ export class Repository {
     this.githubURL = apiRepository.githubURL;
     this.stargazersCount = apiRepository.stargazersCount;
     this.weekStargazersCount = apiRepository.weekStargazersCount;
+    this.isVim = apiRepository.isVim;
+    this.isLua = apiRepository.isLua;
 
     let defaultBackground = Background.Light;
 

--- a/src/models/vimColorScheme.ts
+++ b/src/models/vimColorScheme.ts
@@ -5,6 +5,8 @@ export class VimColorScheme {
   name: string;
   valid: boolean;
   data: VimColorSchemeData;
+  isLua: boolean;
+  isVim: boolean;
   backgrounds: Background[];
   private _defaultBackground: Background;
 
@@ -12,6 +14,8 @@ export class VimColorScheme {
     this.name = apiVimColorScheme?.name || '';
     this.valid = apiVimColorScheme?.valid || false;
     this.data = new VimColorSchemeData(apiVimColorScheme?.data || null);
+    this.isLua = !!apiVimColorScheme?.isLua;
+    this.isVim = !this.isLua;
 
     this.backgrounds = apiVimColorScheme?.backgrounds || [];
 
@@ -43,6 +47,8 @@ export class VimColorScheme {
     copy.name = this.name;
     copy.valid = this.valid;
     copy.data = this.data;
+    copy.isVim = this.isVim;
+    copy.isLua = this.isLua;
     return copy;
   }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -51,10 +51,10 @@ body {
   }
 
   --standard-space: #{rem(16px)};
-  --small-space: calc(var(--standard-space) / 2);
-  --smallest-space: calc(var(--small-space) / 2);
-  --large-space: calc(var(--standard-space) * 2);
-  --largest-space: calc(var(--large-space) * 2);
+  --small-space: calc(var(--standard-space) / 2); // 8px
+  --smallest-space: calc(var(--small-space) / 2); // 4px
+  --large-space: calc(var(--standard-space) * 2); // 32px
+  --largest-space: calc(var(--large-space) * 2); // 64px
 
   --standard-font-family: 'Source Sans Pro', sans-serif;
   --code-font-family: 'Ubuntu Mono', monospace;

--- a/src/templates/preview/index.tsx
+++ b/src/templates/preview/index.tsx
@@ -95,6 +95,8 @@ export const query = graphql`
       lastCommitAt
       githubURL
       weekStargazersCount
+      isVim
+      isLua
       owner {
         name
       }
@@ -102,6 +104,7 @@ export const query = graphql`
         name
         valid
         backgrounds
+        isLua
         data {
           light {
             name

--- a/src/templates/repositories/index.tsx
+++ b/src/templates/repositories/index.tsx
@@ -148,6 +148,8 @@ export const query = graphql`
         lastCommitAt
         githubURL
         weekStargazersCount
+        isVim
+        isLua
         owner {
           name
         }
@@ -155,6 +157,7 @@ export const query = graphql`
           name
           valid
           backgrounds
+          isLua
           data {
             light {
               name

--- a/src/templates/repository/index.tsx
+++ b/src/templates/repository/index.tsx
@@ -107,6 +107,8 @@ export const query = graphql`
       lastCommitAt
       githubURL
       weekStargazersCount
+      isVim
+      isLua
       owner {
         name
       }
@@ -114,6 +116,7 @@ export const query = graphql`
         name
         valid
         backgrounds
+        isLua
         data {
           light {
             name


### PR DESCRIPTION
## Type of PR

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Based on data from the mongo database, add a "pill" on the bottom right of the repo card to display if the color scheme is lua or vim based.

## Related issue

Closes #727 