### PR TITLE
feat: Display neovim (lua) color schemes

### DIFF
--- a/src/gatsby/node.ts
+++ b/src/gatsby/node.ts
@@ -162,10 +162,7 @@ const repositoriesQuery = `
       updateValid: { eq: true }
       generateValid: { eq: true }
       vimColorSchemes: {
-        elemMatch: {
-          valid: { eq: true }
-          isLua: { ne: true }
-        }
+        elemMatch: { valid: { eq: true } }
       }
     }
   ) {

--- a/src/templates/repositories/index.tsx
+++ b/src/templates/repositories/index.tsx
@@ -128,11 +128,7 @@ export const query = graphql`
         updateValid: { eq: true }
         generateValid: { eq: true }
         vimColorSchemes: {
-          elemMatch: {
-            valid: { eq: true }
-            backgrounds: { in: $filters }
-            isLua: { ne: true }
-          }
+          elemMatch: { valid: { eq: true }, backgrounds: { in: $filters } }
         }
       }
       sort: { fields: $sortProperty, order: $sortOrder }


### PR DESCRIPTION
🎉

Remove all filters for neovim color schemes.

Note: only most recently updated neovim color schemes will appear. Some older color schemes will take some time to appear on the website.