### PR TITLE
fix: Update mongodb install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,10 @@ That's it. The script will:
 
 ### 0. Requirements
 
-- Running local install of mongodb-community on macOS: `brew install mongodb-community && brew services start mongodb-community`
+- Running local install of mongodb-community on macOS:
+  1. `brew tap mongodb/brew`
+  2. `brew install mongodb-community`
+  3. `brew services start mongodb-community`
 - Node 12+
 - A locally cloned fork of [the repository](https://github.com/vimcolorschemes/vimcolorschemes). Check out [how to.](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)
 


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [x] Documentation update
- [ ] Tests

## Description

Updates `install.md` to have instructions to `brew tap mongodb/brew` to install mongodb.

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [x] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [ ] no
