### PR TITLE
feat: Add list of colorscheme variations in repository page

### DIFF
--- a/src/app/repositories/[owner]/[name]/page.tsx
+++ b/src/app/repositories/[owner]/[name]/page.tsx
@@ -2,12 +2,9 @@ import { Metadata } from 'next';
 
 import RepositoriesService from '@/services/repositories';
 
-type RepositoryPageProps = {
-  params: {
-    owner: string;
-    name: string;
-  };
-};
+import Preview from '@/components/preview';
+
+type RepositoryPageProps = { params: { owner: string; name: string } };
 
 export async function generateMetadata({
   params,
@@ -17,7 +14,7 @@ export async function generateMetadata({
     params.name,
   );
 
-  return { title: `${repository.title} | vimcolorschemes` };
+  return { title: repository.title };
 }
 
 export default async function RepositoryPage({ params }: RepositoryPageProps) {
@@ -26,5 +23,16 @@ export default async function RepositoryPage({ params }: RepositoryPageProps) {
     params.name,
   );
 
-  return <main>{repository.key}</main>;
+  return (
+    <main>
+      <h1>{repository.key}</h1>
+      {repository.flattenedColorschemes.map((colorscheme, index) => (
+        <Preview
+          key={index}
+          colorscheme={colorscheme}
+          background={colorscheme.backgrounds[0]}
+        />
+      ))}
+    </main>
+  );
 }

--- a/src/components/interactivePreview/index.tsx
+++ b/src/components/interactivePreview/index.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+
+import RepositoryDTO from '@/models/DTO/repository';
+import Repository from '@/models/repository';
+
+import Preview from '@/components/preview';
+
+type InteractivePreviewProps = {
+  repositoryDTO: RepositoryDTO;
+};
+
+export default function InteractivePreview({
+  repositoryDTO,
+}: InteractivePreviewProps) {
+  const repository = new Repository(repositoryDTO);
+
+  const defaultColorscheme = repository.colorschemes[0];
+  const defaultBackground = defaultColorscheme.backgrounds[0];
+
+  const [colorscheme, setColorscheme] = useState(defaultColorscheme);
+  const [background, setBackground] = useState(defaultBackground);
+
+  function onToggleColorscheme() {
+    const index = repository.colorschemes.findIndex(
+      c => c.name === colorscheme.name,
+    );
+    const nextIndex = (index + 1) % repository.colorschemes.length;
+    setColorscheme(repository.colorschemes[nextIndex]);
+  }
+
+  function onToggleBackground() {
+    const index = colorscheme.backgrounds.indexOf(background);
+    const nextIndex = (index + 1) % colorscheme.backgrounds.length;
+    setBackground(colorscheme.backgrounds[nextIndex]);
+  }
+
+  return (
+    <Preview
+      colorscheme={colorscheme}
+      background={background}
+      onToggleColorscheme={
+        repository.colorschemes.length > 1 ? onToggleColorscheme : undefined
+      }
+      onToggleBackground={
+        colorscheme.backgrounds.length > 1 ? onToggleBackground : undefined
+      }
+    />
+  );
+}

--- a/src/components/preview/colorschemeConfig/index.tsx
+++ b/src/components/preview/colorschemeConfig/index.tsx
@@ -1,10 +1,8 @@
-import cn from 'classnames';
 import { ReactNode } from 'react';
 
 import Colorscheme from '@/models/colorscheme';
-import Repository from '@/models/repository';
 
-import Backgrounds, { Background } from '@/lib/backgrounds';
+import { Background } from '@/lib/backgrounds';
 import Engines from '@/lib/engines';
 
 import Code from '@/components/ui/code';
@@ -13,40 +11,18 @@ import IconNext from '@/components/ui/icons/next';
 import styles from './index.module.css';
 
 type ColorschemeConfigProps = {
-  repository: Repository;
   colorscheme: Colorscheme;
   background: Background;
-  onColorschemeChange: (colorscheme: Colorscheme) => void;
-  onBackgroundChange: (background: Background) => void;
+  onToggleBackground?: () => void;
+  onToggleColorscheme?: () => void;
 };
 
 export default function ColorschemeConfig({
-  repository,
   colorscheme,
   background,
-  onColorschemeChange,
-  onBackgroundChange,
+  onToggleColorscheme,
+  onToggleBackground,
 }: ColorschemeConfigProps) {
-  const isColorschemeDisabled = repository.colorschemes.length === 1;
-  const isBackgroundDisabled = colorscheme.backgrounds.length === 1;
-
-  function toggleColorscheme() {
-    const index = repository.colorschemes.findIndex(
-      c => c.name === colorscheme.name,
-    );
-    const nextIndex = (index + 1) % repository.colorschemes.length;
-
-    onColorschemeChange(repository.colorschemes[nextIndex]);
-  }
-
-  function toggleBackground() {
-    if (background === Backgrounds.Light) {
-      onBackgroundChange(Backgrounds.Dark);
-    } else {
-      onBackgroundChange(Backgrounds.Light);
-    }
-  }
-
   const ConfigContent = colorscheme.engine === Engines.Vim ? VimRC : InitLua;
 
   return (
@@ -57,46 +33,29 @@ export default function ColorschemeConfig({
       <ConfigContent
         colorscheme={colorscheme}
         background={background}
-        toggleColorscheme={toggleColorscheme}
-        isColorschemeDisabled={isColorschemeDisabled}
-        toggleBackground={toggleBackground}
-        isBackgroundDisabled={isBackgroundDisabled}
+        onToggleColorscheme={onToggleColorscheme}
+        onToggleBackground={onToggleBackground}
       />
     </Code>
   );
 }
 
-type ConfigContentProps = {
-  colorscheme: Colorscheme;
-  background: Background;
-  toggleColorscheme: () => void;
-  isColorschemeDisabled: boolean;
-  toggleBackground: () => void;
-  isBackgroundDisabled: boolean;
-};
-
 function VimRC({
   colorscheme,
   background,
-  toggleColorscheme,
-  isColorschemeDisabled,
-  toggleBackground,
-  isBackgroundDisabled,
-}: ConfigContentProps) {
+  onToggleColorscheme,
+  onToggleBackground,
+}: ColorschemeConfigProps) {
   return (
     <>
       <div>
         <span className="vimCommand">set </span>background
         <span className="vimCommand">=</span>
-        <Button onClick={toggleBackground} disabled={isBackgroundDisabled}>
-          {background}
-        </Button>
+        <Button onClick={onToggleBackground}>{background}</Button>
       </div>
       <div>
         <span className="vimCommand">colorscheme </span>
-        <Button onClick={toggleColorscheme} disabled={isColorschemeDisabled}>
-          {colorscheme.name}
-        </Button>
+        <Button onClick={onToggleColorscheme}>{colorscheme.name}</Button>
       </div>
     </>
   );
@@ -105,20 +64,16 @@ function VimRC({
 function InitLua({
   colorscheme,
   background,
-  toggleColorscheme,
-  isColorschemeDisabled,
-  toggleBackground,
-  isBackgroundDisabled,
-}: ConfigContentProps) {
+  onToggleColorscheme,
+  onToggleBackground,
+}: ColorschemeConfigProps) {
   return (
     <>
       <div>
         <span className="vimCommand">{'vim.o.background = '}</span>
         <span className="vimString">
           {'"'}
-          <Button onClick={toggleBackground} disabled={isBackgroundDisabled}>
-            {background}
-          </Button>
+          <Button onClick={onToggleBackground}>{background}</Button>
           {'"'}
         </span>
       </div>
@@ -127,9 +82,7 @@ function InitLua({
         <span className="vimParenSep">{'('}</span>
         <span className="vimString">
           {'"colorscheme '}
-          <Button onClick={toggleColorscheme} disabled={isColorschemeDisabled}>
-            {colorscheme.name}
-          </Button>
+          <Button onClick={onToggleColorscheme}>{colorscheme.name}</Button>
           {'"'}
         </span>
         <span className="vimParenSep">{')'}</span>
@@ -140,20 +93,19 @@ function InitLua({
 
 type ButtonProps = {
   children: ReactNode;
-  onClick: () => void;
-  disabled: boolean;
+  onClick?: () => void;
 };
 
-function Button({ children, onClick, disabled }: ButtonProps) {
+function Button({ children, onClick }: ButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      disabled={disabled}
+      disabled={!onClick}
       className={styles.button}
     >
       {children}
-      {!disabled && <IconNext />}
+      {onClick && <IconNext />}
     </button>
   );
 }

--- a/src/components/preview/index.tsx
+++ b/src/components/preview/index.tsx
@@ -1,10 +1,6 @@
-'use client';
+import Colorscheme from '@/models/colorscheme';
 
-import { useState } from 'react';
-
-import { ColorschemeGroup } from '@/models/colorscheme';
-import RepositoryDTO from '@/models/DTO/repository';
-import Repository from '@/models/repository';
+import { Background } from '@/lib/backgrounds';
 
 import CodeSnippet from './codeSnippet';
 import ColorschemeConfig from './colorschemeConfig';
@@ -12,19 +8,15 @@ import styles from './index.module.css';
 import WindowHeader from './windowHeader';
 
 type PreviewProps = {
-  repositoryDTO: RepositoryDTO;
+  colorscheme: Colorscheme;
+  background: Background;
+  onToggleColorscheme?: () => void;
+  onToggleBackground?: () => void;
 };
 
-export default function Preview({ repositoryDTO }: PreviewProps) {
-  const repository = new Repository(repositoryDTO);
-  const defaultColorscheme = repository.colorschemes[0];
-  const defaultBackground = defaultColorscheme.backgrounds[0];
-
-  const [colorscheme, setColorscheme] = useState(defaultColorscheme);
-  const [background, setBackground] = useState(defaultBackground);
-
-  const style = colorscheme.data[background]?.reduce(
-    (acc, group: ColorschemeGroup) => ({
+export default function Preview(props: PreviewProps) {
+  const style = props.colorscheme.data[props.background]?.reduce(
+    (acc, group) => ({
       ...acc,
       [`--colorscheme-${group.name}`]: group.hexCode,
     }),
@@ -33,13 +25,15 @@ export default function Preview({ repositoryDTO }: PreviewProps) {
 
   return (
     <div className={styles.container} style={style}>
-      <WindowHeader title={colorscheme.name} engines={repository.engines} />
+      <WindowHeader
+        title={props.colorscheme.name}
+        engine={props.colorscheme.engine}
+      />
       <ColorschemeConfig
-        repository={repository}
-        colorscheme={colorscheme}
-        background={background}
-        onColorschemeChange={setColorscheme}
-        onBackgroundChange={setBackground}
+        colorscheme={props.colorscheme}
+        background={props.background}
+        onToggleColorscheme={props.onToggleColorscheme}
+        onToggleBackground={props.onToggleBackground}
       />
       <CodeSnippet />
     </div>

--- a/src/components/preview/windowHeader/index.tsx
+++ b/src/components/preview/windowHeader/index.tsx
@@ -1,16 +1,18 @@
+import { Engine } from '@/lib/engines';
+
 import styles from './index.module.css';
 
 type WindowHeaderProps = {
   title: string;
-  engines: string[];
+  engine: Engine;
 };
 
-export default function WindowHeader({ title, engines }: WindowHeaderProps) {
+export default function WindowHeader({ title, engine }: WindowHeaderProps) {
   return (
     <div className={styles.container}>
       <div className={styles.buttons} />
       <div className={styles.title}>{title}</div>
-      <div className={styles.engine}>{engines.join('/')}</div>
+      <div className={styles.engine}>{engine}</div>
     </div>
   );
 }

--- a/src/components/repositoryCard/index.tsx
+++ b/src/components/repositoryCard/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 import Repository from '@/models/repository';
 
-import Preview from '@/components/preview';
+import InteractivePreview from '@/components/interactivePreview';
 import Card from '@/components/ui/card';
 
 type RepositoryCardProps = {
@@ -12,7 +12,7 @@ type RepositoryCardProps = {
 export default function RepositoryCard({ repository }: RepositoryCardProps) {
   return (
     <Card>
-      <Preview repositoryDTO={repository.toDTO()} />
+      <InteractivePreview repositoryDTO={repository.dto} />
       <Link href={repository.route}>
         <h2>{repository.key}</h2>
         <p>{repository.description}</p>

--- a/src/models/DTO/repository.ts
+++ b/src/models/DTO/repository.ts
@@ -13,7 +13,7 @@ type RepositoryDTO = {
   stargazersCount: number;
   weekStargazersCount: number;
   isLua: boolean;
-  colorschemes: ColorschemeDTO[] | null;
+  colorschemes: ColorschemeDTO[];
 };
 
 const RepositorySchema = new mongoose.Schema<RepositoryDTO>({

--- a/src/models/colorscheme.ts
+++ b/src/models/colorscheme.ts
@@ -1,4 +1,4 @@
-import { Background } from '@/lib/backgrounds';
+import Backgrounds, { Background } from '@/lib/backgrounds';
 import Engines, { Engine } from '@/lib/engines';
 
 import ColorschemeDTO, { ColorschemeDataDTO } from './DTO/colorscheme';
@@ -16,17 +16,38 @@ class Colorscheme {
     this.backgrounds = dto?.backgrounds || [];
   }
 
-  toDTO(): ColorschemeDTO {
+  /**
+   * @returns a DTO representation of the colorscheme.
+   */
+  get dto(): ColorschemeDTO {
     return {
       name: this.name,
-      data: this.data.toDTO(),
+      data: this.data.dto,
       isLua: this.engine === Engines.Neovim,
       backgrounds: this.backgrounds,
     };
   }
+
+  /**
+   * @returns a list of flat colorschemes, where each colorscheme has only one background.
+   */
+  get flattened(): Colorscheme[] {
+    return this.backgrounds.map(
+      background =>
+        new Colorscheme({
+          name: this.name,
+          isLua: this.engine === Engines.Neovim,
+          backgrounds: [background],
+          data: new ColorschemeData({
+            light: background === Backgrounds.Light ? this.data.light : null,
+            dark: background === Backgrounds.Dark ? this.data.dark : null,
+          }),
+        }),
+    );
+  }
 }
 
-class ColorschemeData {
+export class ColorschemeData {
   light: ColorschemeGroup[] | null;
   dark: ColorschemeGroup[] | null;
 
@@ -35,7 +56,10 @@ class ColorschemeData {
     this.dark = !!dto?.dark?.length ? dto.dark : null;
   }
 
-  toDTO(): ColorschemeDataDTO {
+  /**
+   * @returns a DTO representation of the colorscheme data.
+   */
+  get dto(): ColorschemeDataDTO {
     return {
       light: this.light || [],
       dark: this.dark || [],

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -1,7 +1,7 @@
-import { Background } from '@/lib/backgrounds';
+import Backgrounds, { Background } from '@/lib/backgrounds';
 import Engines, { Engine } from '@/lib/engines';
 
-import Colorscheme from './colorscheme';
+import Colorscheme, { ColorschemeData } from './colorscheme';
 import RepositoryDTO from './DTO/repository';
 import Owner from './owner';
 
@@ -30,18 +30,30 @@ class Repository {
     );
   }
 
+  /**
+   * @returns The unique key of the repository, used to identify it in various contexts.
+   */
   get key(): string {
     return `${this.owner.name}/${this.name}`;
   }
 
+  /**
+   * @returns The route of the repository, used to navigate to the repository page.
+   */
   get route(): string {
     return `/repositories/${this.key}`.toLowerCase();
   }
 
+  /**
+   * @returns The page title of the repository composed by the name and the owner's name.
+   */
   get title(): string {
     return `${this.name}, by ${this.owner.name}`;
   }
 
+  /**
+   * @returns A list of backgrounds used by the colorschemes in this repository.
+   */
   get backgrounds(): Background[] {
     return Array.from(
       new Set(
@@ -50,13 +62,19 @@ class Repository {
     );
   }
 
+  /**
+   * @returns A list of engines used by the colorschemes in this repository.
+   */
   get engines(): Engine[] {
     return Array.from(
       new Set(this.colorschemes.map(colorscheme => colorscheme.engine)),
     );
   }
 
-  toDTO(): RepositoryDTO {
+  /**
+   * @returns The DTO version of this repository. Equivalent of the object that comes from the API.
+   */
+  get dto(): RepositoryDTO {
     return {
       name: this.name,
       owner: this.owner,
@@ -67,8 +85,15 @@ class Repository {
       stargazersCount: this.stargazersCount,
       weekStargazersCount: this.weekStargazersCount,
       isLua: this.engines.includes(Engines.Neovim),
-      colorschemes: this.colorschemes.map(colorscheme => colorscheme.toDTO()),
+      colorschemes: this.colorschemes.map(colorscheme => colorscheme.dto),
     };
+  }
+
+  /**
+   * @returns a list of flat colorschemes, where each colorscheme has only one background.
+   */
+  get flattenedColorschemes(): Colorscheme[] {
+    return this.colorschemes.flatMap(colorscheme => colorscheme.flattened);
   }
 }
 


### PR DESCRIPTION
* Flattens all repository colorscheme into non-interactive previews, and lists them all.