### PR TITLE
feat: remove owner filter from index pages

### DIFF
--- a/src/__tests__/app/api/repositories/route.test.ts
+++ b/src/__tests__/app/api/repositories/route.test.ts
@@ -109,21 +109,9 @@ describe('GET /api/repositories', () => {
     });
   });
 
-  it('passes owner filter to service', async () => {
-    const response = await GET(makeRequest('?owner=morhetz'));
-
-    expect(response.status).toBe(200);
-    expect(repositoriesServiceMock.getRepositoryDTOPage).toHaveBeenCalledWith({
-      sort: SortOptions.Trending,
-      filter: { page: 1, owner: 'morhetz' },
-    });
-  });
-
   it('passes all filters together', async () => {
     const response = await GET(
-      makeRequest(
-        '?sort=new&search=gruvbox&background=light&page=2&owner=morhetz',
-      ),
+      makeRequest('?sort=new&background=light&page=2'),
     );
 
     expect(response.status).toBe(200);
@@ -132,13 +120,11 @@ describe('GET /api/repositories', () => {
       filter: {
         page: 2,
         background: 'light',
-        owner: 'morhetz',
       },
     });
     expect(repositoriesServiceMock.getRepositoryCount).toHaveBeenCalledWith({
       page: 2,
       background: 'light',
-      owner: 'morhetz',
     });
   });
 

--- a/src/app/(index)/i/[...filters]/page.tsx
+++ b/src/app/(index)/i/[...filters]/page.tsx
@@ -16,7 +16,7 @@ import Repositories from '@/components/repositories';
 
 import styles from './page.module.css';
 
-export const dynamicParams = true;
+export const dynamicParams = false;
 
 export function generateStaticParams() {
   const sorts = Object.values(SortOptions);

--- a/src/app/api/repositories/route.ts
+++ b/src/app/api/repositories/route.ts
@@ -38,11 +38,6 @@ export async function GET(request: NextRequest) {
   }
   filter.page = page;
 
-  const owner = searchParams.get('owner');
-  if (owner) {
-    filter.owner = owner;
-  }
-
   const [{ repositories, hasMore }, count] = await Promise.all([
     RepositoriesService.getRepositoryDTOPage({ sort, filter }),
     RepositoriesService.getRepositoryCount(filter),

--- a/src/components/repositories/index.tsx
+++ b/src/components/repositories/index.tsx
@@ -18,25 +18,15 @@ type RepositoriesProps = {
 };
 
 function buildTitle(filter: PageContext['filter']): string {
-  if (!filter.background && !filter.owner) {
+  if (!filter.background) {
     return 'All';
   }
 
-  const parts: string[] = [];
-
-  if (filter.background) {
-    if (filter.background === 'both') {
-      parts.push('with light and dark background');
-    } else {
-      parts.push(`with ${filter.background} background`);
-    }
+  if (filter.background === 'both') {
+    return 'with light and dark background';
   }
 
-  if (filter.owner) {
-    parts.push(`${filter.owner}'s work`);
-  }
-
-  return parts.join(' ');
+  return `with ${filter.background} background`;
 }
 
 export default function Repositories({ pageContext }: RepositoriesProps) {

--- a/src/helpers/pageContext.ts
+++ b/src/helpers/pageContext.ts
@@ -42,7 +42,7 @@ function getPageTitle({ filter, sort }: PageContext): string {
 }
 
 function isHomepage({ filter, sort }: PageContext): boolean {
-  return sort === SortOptions.Trending && !filter.background && !filter.owner;
+  return sort === SortOptions.Trending && !filter.background;
 }
 
 export const PageContextHelper = {

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -2,18 +2,15 @@ import { Background } from './backgrounds';
 
 export const URLFilterKeys = {
   Background: 'b',
-  Owner: 'a',
 } as const;
 export type URLFilterKey = (typeof URLFilterKeys)[keyof typeof URLFilterKeys];
 
 export const FilterURLKeyMap: Partial<Record<keyof Filter, URLFilterKey>> = {
   background: URLFilterKeys.Background,
-  owner: URLFilterKeys.Owner,
 };
 
 export const URLKeyFilterMap: Record<URLFilterKey, keyof Filter> = {
   [URLFilterKeys.Background]: 'background',
-  [URLFilterKeys.Owner]: 'owner',
 };
 
 export type BackgroundFilter = Background | 'both';

--- a/src/services/repositoriesClient.ts
+++ b/src/services/repositoriesClient.ts
@@ -30,10 +30,6 @@ function buildSearchParams({
     params.set('background', filter.background);
   }
 
-  if (filter?.owner) {
-    params.set('owner', filter.owner);
-  }
-
   return params;
 }
 


### PR DESCRIPTION
- remove owner URL filter mapping, API param, and client-side owner param
- set dynamicParams = false — all index routes are now statically generated