### PR TITLE
fix: match static search control geometry

### DIFF
--- a/src/__tests__/components/exploreCommandInput.test.tsx
+++ b/src/__tests__/components/exploreCommandInput.test.tsx
@@ -9,6 +9,7 @@ import type { PageContext } from '@/lib/pageContext';
 import { SortOptions } from '@/lib/sort';
 
 import ExploreCommandInput from '@/components/exploreCommandInput';
+import ExploreCommand from '@/components/exploreCommandInput/command';
 
 const navigation = vi.hoisted(() => ({
   pathname: '/i/trending',
@@ -163,6 +164,48 @@ describe('ExploreCommandInput', () => {
         name: 'Search repositories',
       }).style.width,
     ).toBe('');
+  });
+
+  it('does not draw an extra outline around the focused search input', () => {
+    const commandStyles = readFileSync(
+      join(
+        process.cwd(),
+        'src/components/exploreCommandInput/index.module.css',
+      ),
+      'utf8',
+    );
+
+    expect(commandStyles).not.toContain('.searchInput:focus-visible');
+    expect(commandStyles).toContain('.searchSubmit:focus-visible');
+  });
+
+  it('reserves the complete search control geometry in the static fallback', () => {
+    const { container } = render(
+      <ExploreCommand interactive={false} pageContext={fallbackPageContext} />,
+    );
+    const searchForm = Array.from(container.querySelectorAll('span')).find(
+      element => element.className.includes('searchForm'),
+    );
+
+    expect(searchForm).toBeDefined();
+    expect(
+      Array.from(searchForm?.children ?? []).some(element =>
+        element.className.includes('searchInput'),
+      ),
+    ).toBe(true);
+    expect(
+      Array.from(searchForm?.querySelectorAll('span') ?? []).some(
+        element =>
+          element.className.includes('searchLoading') &&
+          element.textContent === 'Loading',
+      ),
+    ).toBe(true);
+    expect(
+      Array.from(searchForm?.children ?? []).some(element =>
+        element.className.includes('searchSubmit'),
+      ),
+    ).toBe(true);
+    expect(searchForm?.textContent).toContain('↵');
   });
 
   it('renders the submitted search value in the normal input', () => {

--- a/src/components/exploreCommandInput/command.tsx
+++ b/src/components/exploreCommandInput/command.tsx
@@ -6,6 +6,7 @@ import { SortOptions } from '@/lib/sort';
 import { buildIndexRoutePath } from '@/helpers/indexRoute';
 
 import HomeCommand from '@/components/homeCommand';
+import { TuiLoadingInline } from '@/components/ui/tuiLoading';
 
 import CommandMenu from './commandMenu';
 import styles from './index.module.css';
@@ -53,7 +54,12 @@ export default function ExploreCommand({
   ) : (
     <span className={styles.tuiControl}>
       <span className={styles.tuiLabel}>search</span>
-      <span className={styles.searchInput} aria-hidden="true" />
+      <span className={styles.searchForm} aria-hidden="true">
+        <span className={styles.searchInput}>
+          <TuiLoadingInline className={styles.searchLoading} />
+        </span>
+        <span className={styles.searchSubmit}>↵</span>
+      </span>
     </span>
   );
 

--- a/src/components/exploreCommandInput/index.module.css
+++ b/src/components/exploreCommandInput/index.module.css
@@ -116,6 +116,12 @@
   caret-color: var(--foreground-accent);
 }
 
+.searchLoading {
+  color: var(--foreground-shade);
+  font-size: 0.72em;
+  opacity: 0.64;
+}
+
 .searchSubmit {
   appearance: none;
   display: inline-flex;
@@ -159,7 +165,6 @@
   caret-color: var(--background);
 }
 
-.searchInput:focus-visible,
 .searchSubmit:focus-visible {
   outline: 1px solid currentColor;
   outline-offset: 1px;


### PR DESCRIPTION
* mirror the interactive search geometry in the static fallback
* retain the parent-level focus indicator without an extra input outline
* cover the fallback structure and focus styles with tests