### PR TITLE
feat: show loading feedback for repository search

### DIFF
--- a/src/__tests__/components/exploreCommandInput.test.tsx
+++ b/src/__tests__/components/exploreCommandInput.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -65,6 +65,8 @@ const fallbackPageContext: PageContext = {
 };
 
 describe('ExploreCommandInput', () => {
+  afterEach(() => vi.useRealTimers());
+
   beforeEach(() => {
     navigation.pathname = '/i/trending';
     navigation.replace.mockClear();
@@ -525,6 +527,58 @@ describe('ExploreCommandInput', () => {
         scroll: false,
       },
     );
+  });
+
+  it('shows a loading state as soon as a search is submitted', () => {
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: 'Search repositories' }),
+      {
+        target: { value: 'catppuccin' },
+      },
+    );
+    fireEvent.submit(
+      screen.getByRole('searchbox', { name: 'Search repositories' }),
+    );
+
+    expect(screen.getByRole('search').getAttribute('aria-busy')).toBe('true');
+    expect(screen.getByRole('status').textContent).toBe(
+      'searching repositories',
+    );
+    expect(
+      screen.getByRole<HTMLButtonElement>('button', {
+        name: 'Submit repository search',
+      }).disabled,
+    ).toBe(true);
+  });
+
+  it('clears the loading state after the submitted search is shown', async () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <ExploreCommandInput fallbackPageContext={fallbackPageContext} />,
+    );
+
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: 'Search repositories' }),
+      {
+        target: { value: 'catppuccin' },
+      },
+    );
+    fireEvent.submit(
+      screen.getByRole('searchbox', { name: 'Search repositories' }),
+    );
+    navigation.searchParams = new URLSearchParams({ q: 'catppuccin' });
+    rerender(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    await act(() => vi.advanceTimersByTimeAsync(250));
+
+    expect(screen.getByRole('search').getAttribute('aria-busy')).toBe('false');
+    expect(
+      screen.getByRole<HTMLButtonElement>('button', {
+        name: 'Submit repository search',
+      }).disabled,
+    ).toBe(false);
   });
 
   it('removes the search query when blank text is submitted', () => {

--- a/src/components/exploreCommandInput/index.module.css
+++ b/src/components/exploreCommandInput/index.module.css
@@ -145,6 +145,11 @@
   white-space: nowrap;
 }
 
+.searchSubmit .searchSubmitLoading {
+  --tui-loading-cell-size: 0.28em;
+  --tui-loading-cell-gap: 0.08em;
+}
+
 .searchInput::-webkit-search-cancel-button,
 .searchInput::-webkit-search-decoration {
   appearance: none;

--- a/src/components/exploreCommandInput/searchInput.tsx
+++ b/src/components/exploreCommandInput/searchInput.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, useId } from 'react';
+import { type FormEvent, useEffect, useId, useState } from 'react';
 
 import { RepositorySearchManifestClient } from '@/services/repositorySearchManifestClient';
 
+import { TuiLoadingInline } from '@/components/ui/tuiLoading';
+
 import styles from './index.module.css';
+
+const MINIMUM_SEARCH_FEEDBACK_MS = 250;
+const MAXIMUM_SEARCH_FEEDBACK_MS = 10_000;
 
 export default function SearchInput() {
   const pathname = usePathname();
@@ -13,6 +18,35 @@ export default function SearchInput() {
   const searchParams = useSearchParams();
   const query = searchParams.get('q') ?? '';
   const inputId = useId();
+  const currentSearch = searchParams.toString();
+  const currentURL = currentSearch ? `${pathname}?${currentSearch}` : pathname;
+  const [pendingSearch, setPendingSearch] = useState<{
+    startedAt: number;
+    url: string;
+  } | null>(null);
+  const isSearching = pendingSearch !== null;
+
+  useEffect(() => {
+    if (!pendingSearch) {
+      return;
+    }
+
+    const navigationFinished = currentURL === pendingSearch.url;
+    const feedbackDuration = navigationFinished
+      ? MINIMUM_SEARCH_FEEDBACK_MS
+      : MAXIMUM_SEARCH_FEEDBACK_MS;
+    const remainingDuration = Math.max(
+      0,
+      feedbackDuration - (Date.now() - pendingSearch.startedAt),
+    );
+    const timeout = window.setTimeout(() => {
+      setPendingSearch(currentSearch =>
+        currentSearch === pendingSearch ? null : currentSearch,
+      );
+    }, remainingDuration);
+
+    return () => window.clearTimeout(timeout);
+  }, [currentURL, pendingSearch]);
 
   function preloadManifest() {
     void RepositorySearchManifestClient.loadRepositorySearchManifest().catch(
@@ -34,42 +68,64 @@ export default function SearchInput() {
     }
 
     const search = nextSearchParams.toString();
-    router.replace(search ? `${pathname}?${search}` : pathname, {
+    const nextURL = search ? `${pathname}?${search}` : pathname;
+
+    setPendingSearch({ startedAt: Date.now(), url: nextURL });
+    router.replace(nextURL, {
       scroll: false,
     });
   }
 
   return (
-    <form
-      action={pathname}
-      className={styles.tuiControl}
-      method="get"
-      role="search"
-      onSubmit={submitSearch}
-    >
-      <label className={styles.tuiLabel} htmlFor={inputId}>
-        search<span className={styles.visuallyHidden}> repositories</span>
-      </label>
-      <span className={styles.searchForm}>
-        <input
-          aria-label="Search repositories"
-          className={styles.searchInput}
-          defaultValue={query}
-          id={inputId}
-          key={query}
-          name="q"
-          type="search"
-          onChange={preloadManifest}
-          onFocus={preloadManifest}
-        />
-        <button
-          aria-label="Submit repository search"
-          className={styles.searchSubmit}
-          type="submit"
-        >
-          ↵
-        </button>
+    <>
+      <form
+        action={pathname}
+        className={styles.tuiControl}
+        method="get"
+        role="search"
+        aria-busy={isSearching}
+        onSubmit={submitSearch}
+      >
+        <label className={styles.tuiLabel} htmlFor={inputId}>
+          search<span className={styles.visuallyHidden}> repositories</span>
+        </label>
+        <span className={styles.searchForm}>
+          <input
+            aria-label="Search repositories"
+            className={styles.searchInput}
+            defaultValue={query}
+            id={inputId}
+            key={query}
+            name="q"
+            type="search"
+            onChange={preloadManifest}
+            onFocus={preloadManifest}
+          />
+          <button
+            aria-label="Submit repository search"
+            className={styles.searchSubmit}
+            disabled={isSearching}
+            type="submit"
+          >
+            {isSearching ? (
+              <TuiLoadingInline
+                announce={false}
+                className={styles.searchSubmitLoading}
+              />
+            ) : (
+              '↵'
+            )}
+          </button>
+        </span>
+      </form>
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        className={styles.visuallyHidden}
+        role="status"
+      >
+        {isSearching ? 'searching repositories' : ''}
       </span>
-    </form>
+    </>
   );
 }

--- a/src/components/ui/tuiLoading/index.tsx
+++ b/src/components/ui/tuiLoading/index.tsx
@@ -34,14 +34,19 @@ export default function TuiLoading({
 }
 
 type TuiLoadingInlineProps = {
+  announce?: boolean;
   className?: string;
 };
 
-export function TuiLoadingInline({ className }: TuiLoadingInlineProps) {
+export function TuiLoadingInline({
+  announce = true,
+  className,
+}: TuiLoadingInlineProps) {
   return (
     <span
-      role="status"
-      aria-busy="true"
+      role={announce ? 'status' : undefined}
+      aria-busy={announce ? 'true' : undefined}
+      aria-hidden={announce ? undefined : true}
       className={cn(styles.inline, className)}
     >
       <span className={styles.srOnly}>Loading</span>


### PR DESCRIPTION
* show accessible loading feedback while repository search navigation is pending
* keep feedback visible briefly and clear it after navigation, with a bounded fallback
* cover loading and completion states with tests