### PR TITLE
feat: add repository controls reset

### DIFF
--- a/src/__tests__/components/exploreCommandInput.test.tsx
+++ b/src/__tests__/components/exploreCommandInput.test.tsx
@@ -142,6 +142,89 @@ describe('ExploreCommandInput', () => {
     ).toBe('/i/old/b.light?q=tokyo+night');
   });
 
+  it('resets repository search, filters, and sorting together', () => {
+    navigation.pathname = '/i/old/b.dark';
+    navigation.searchParams = new URLSearchParams({ q: 'tokyo night' });
+
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    const reset = screen.getByRole('link', {
+      name: 'Reset repository search, filters, and sorting',
+    });
+
+    expect(reset.textContent).toBe('reset');
+    expect(reset.getAttribute('href')).toBe('/i/trending');
+  });
+
+  it('does not show reset when repository controls are at their defaults', () => {
+    navigation.searchParams = new URLSearchParams({ q: '   ' });
+
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'Reset repository search, filters, and sorting',
+      }),
+    ).toBeNull();
+  });
+
+  it('shows reset when only repository search is active', () => {
+    navigation.searchParams = new URLSearchParams({ q: 'tokyo night' });
+
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Reset repository search, filters, and sorting',
+      }),
+    ).toBeDefined();
+  });
+
+  it.each(['/i/old', '/i/trending/b.dark'])(
+    'shows reset for non-default path state at %s',
+    pathname => {
+      navigation.pathname = pathname;
+
+      render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+      expect(
+        screen.getByRole('link', {
+          name: 'Reset repository search, filters, and sorting',
+        }),
+      ).toBeDefined();
+    },
+  );
+
+  it('reflects the default controls after reset navigation', () => {
+    navigation.pathname = '/i/old/b.dark';
+    navigation.searchParams = new URLSearchParams({ q: 'tokyo night' });
+
+    const { rerender } = render(
+      <ExploreCommandInput fallbackPageContext={fallbackPageContext} />,
+    );
+
+    navigation.pathname = '/i/trending';
+    navigation.searchParams = new URLSearchParams();
+    rerender(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    expect(
+      screen.getByRole('button', { name: /Order repositories/ }).textContent,
+    ).toBe('trending');
+    expect(
+      screen.getByRole('button', { name: /Filter by background/ }).textContent,
+    ).toBe('any');
+    expect(
+      screen.getByRole<HTMLInputElement>('searchbox', {
+        name: 'Search repositories',
+      }).value,
+    ).toBe('');
+    expect(
+      screen.queryByRole('link', {
+        name: 'Reset repository search, filters, and sorting',
+      }),
+    ).toBeNull();
+  });
+
   it('shows filters as part of the TUI after the explore command', () => {
     render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
 
@@ -211,6 +294,11 @@ describe('ExploreCommandInput', () => {
       ),
     ).toBe(true);
     expect(searchForm?.textContent).toContain('↵');
+    expect(
+      screen.queryByRole('link', {
+        name: 'Reset repository search, filters, and sorting',
+      }),
+    ).toBeNull();
   });
 
   it('renders the submitted search value in the normal input', () => {

--- a/src/components/exploreCommandInput/command.tsx
+++ b/src/components/exploreCommandInput/command.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useId } from 'react';
 
 import { Backgrounds } from '@/lib/backgrounds';
@@ -6,6 +7,7 @@ import type { PageContext } from '@/lib/pageContext';
 import { SortOptions } from '@/lib/sort';
 
 import { buildIndexRoutePath } from '@/helpers/indexRoute';
+import { PageContextHelper } from '@/helpers/pageContext';
 
 import HomeCommand from '@/components/homeCommand';
 import { TuiLoadingInline } from '@/components/ui/tuiLoading';
@@ -15,6 +17,10 @@ import styles from './index.module.css';
 import SearchInput from './searchInput';
 
 const sortOptions = Object.values(SortOptions);
+const resetHref = buildIndexRoutePath({
+  sort: SortOptions.Trending,
+  filter: {},
+});
 const backgroundOptions: {
   value: BackgroundFilter | undefined;
   label: string;
@@ -38,6 +44,10 @@ export default function ExploreCommand({
 }: ExploreCommandProps) {
   const orderId = useId();
   const backgroundId = useId();
+  const canReset =
+    interactive &&
+    (!PageContextHelper.isHomepage(pageContext) ||
+      Boolean(searchQuery?.trim()));
 
   const commandLead = (
     <span className={styles.shellLine}>
@@ -143,6 +153,17 @@ export default function ExploreCommand({
         <span className={styles.filterGroup}>
           {orderControl}
           {backgroundControl}
+          {canReset && (
+            <Link
+              aria-label="Reset repository search, filters, and sorting"
+              className={styles.resetControl}
+              href={resetHref}
+              prefetch={false}
+              scroll={false}
+            >
+              reset
+            </Link>
+          )}
         </span>
       </div>
     </section>

--- a/src/components/exploreCommandInput/index.module.css
+++ b/src/components/exploreCommandInput/index.module.css
@@ -78,6 +78,19 @@
   color: var(--foreground-shade);
 }
 
+.resetControl {
+  color: var(--foreground-shade);
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.resetControl:focus-visible {
+  outline: none;
+  background: var(--foreground-accent);
+  color: var(--background);
+}
+
 .visuallyHidden {
   position: absolute;
   width: 1px;
@@ -211,6 +224,11 @@
 
   .searchSubmit:hover {
     color: var(--foreground-accent);
+  }
+
+  .resetControl:hover {
+    color: var(--foreground);
+    text-decoration: none;
   }
 
   .searchForm:focus-within .searchSubmit {


### PR DESCRIPTION
* show a reset link when search, filter, or sort state is active
* return to the default trending repository route
* cover active and default control states