### PR TITLE
fix: show loading state while search parameters resolve

### DIFF
--- a/src/__tests__/app/indexPage.test.tsx
+++ b/src/__tests__/app/indexPage.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/components/repositories', () => ({
   default: () => <section data-testid="repositories" />,
 }));
 
+vi.mock('@/components/repositories/skeleton', () => ({
+  default: () => <section data-testid="repositories-loading" />,
+}));
+
 vi.mock('@/components/repositories/search', () => ({
   default: ({ query }: { query: string }) => (
     <section data-testid="repository-search" data-query={query} />
@@ -63,14 +67,15 @@ describe('IndexPage', () => {
     ).toBe('tokyo');
   });
 
-  it('uses query-independent static content as the search fallback', async () => {
+  it('uses a loading state while search parameters resolve', async () => {
     const page = await renderIndexPage({ q: 'tokyo' });
     const fallback = page.type === Suspense ? page.props.fallback : null;
 
     render(fallback);
 
-    expect(screen.getByTestId('featured')).toBeDefined();
-    expect(screen.getByTestId('repositories')).toBeDefined();
+    expect(screen.getByTestId('repositories-loading')).toBeDefined();
+    expect(screen.queryByTestId('featured')).toBeNull();
+    expect(screen.queryByTestId('repositories')).toBeNull();
     expect(screen.queryByTestId('repository-search')).toBeNull();
   });
 

--- a/src/app/(index)/i/[...filters]/page.tsx
+++ b/src/app/(index)/i/[...filters]/page.tsx
@@ -1,4 +1,3 @@
-import cn from 'classnames';
 import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
@@ -17,6 +16,7 @@ import FeaturedRepositories, {
   FeaturedRepositoriesSkeleton,
 } from '@/components/featuredRepositories';
 import Repositories from '@/components/repositories';
+import RepositoriesSkeleton from '@/components/repositories/skeleton';
 
 import IndexPageContent from './content';
 import styles from './page.module.css';
@@ -75,12 +75,8 @@ export default async function IndexPage({ params }: IndexPageProps) {
   return (
     <Suspense
       fallback={
-        <div
-          className={cn(styles.homepageContent, {
-            [styles.homepageContentWithFeatured]: isHomepage,
-          })}
-        >
-          {content}
+        <div className={styles.homepageContent}>
+          <RepositoriesSkeleton />
         </div>
       }
     >


### PR DESCRIPTION
* show the repository loading skeleton while search parameters resolve
* prevent stale homepage content from appearing in the search fallback
* update the index page test to cover the loading state