### PR TITLE
fix: preserve search behind repository modal

### DIFF
--- a/src/__tests__/components/repositorySearch.test.tsx
+++ b/src/__tests__/components/repositorySearch.test.tsx
@@ -57,6 +57,33 @@ afterEach(() => {
 });
 
 describe('RepositorySearch', () => {
+  it('preserves the active search in repository result links', () => {
+    const result = repository(1);
+    result.vimColorSchemes.push({
+      name: 'palette-alt',
+      backgrounds: ['dark'],
+      data: {
+        light: null,
+        dark: [
+          { name: 'NormalBg', hexCode: '#111111' },
+          { name: 'NormalFg', hexCode: '#eeeeee' },
+        ],
+      },
+    });
+    renderSearch([result], 'searchable palette');
+
+    const link = screen.getByRole('link', { name: 'palette-1, by local' });
+    expect(link.getAttribute('href')).toBe(
+      '/r/local/palette-1?q=searchable+palette',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /"palette-1".*⟳/ }));
+
+    expect(link.getAttribute('href')).toBe(
+      '/r/local/palette-1?colorscheme=palette-alt&background=dark&q=searchable+palette',
+    );
+  });
+
   it('exposes the result count and visible results as an accessible status', () => {
     renderSearch([repository(1)]);
 

--- a/src/components/repositories/grid/index.tsx
+++ b/src/components/repositories/grid/index.tsx
@@ -11,11 +11,13 @@ import styles from './index.module.css';
 type RepositoriesGridProps = {
   repositories: RepositoryDTO[];
   pageContext: PageContext;
+  searchQuery?: string;
 };
 
 export default function RepositoriesGrid({
   repositories,
   pageContext,
+  searchQuery,
 }: RepositoriesGridProps) {
   const cardClassName = PageContextHelper.isHomepage(pageContext)
     ? styles.homepageCard
@@ -28,6 +30,7 @@ export default function RepositoriesGrid({
           key={`${repository.owner.name}/${repository.name}`}
           repositoryDTO={repository}
           pageContext={pageContext}
+          searchQuery={searchQuery}
           className={cardClassName}
         />
       ))}

--- a/src/components/repositories/search/index.tsx
+++ b/src/components/repositories/search/index.tsx
@@ -100,6 +100,7 @@ export default function RepositorySearch({
             <RepositoriesGrid
               repositories={searchResult.repositories}
               pageContext={pageContext}
+              searchQuery={query}
             />
           )}
           {searchResult.repositories.length === 0 && (

--- a/src/components/repositoryCard/index.tsx
+++ b/src/components/repositoryCard/index.tsx
@@ -12,6 +12,7 @@ import RepositoryCardInteractivePreviewLink from './interactivePreviewLink';
 type RepositoryCardProps = {
   repositoryDTO: RepositoryDTO;
   pageContext: PageContext;
+  searchQuery?: string;
   className?: string;
   headingLevel?: 'h2' | 'h3';
 };
@@ -19,6 +20,7 @@ type RepositoryCardProps = {
 export default function RepositoryCard({
   repositoryDTO,
   pageContext,
+  searchQuery,
   className,
   headingLevel,
 }: RepositoryCardProps) {
@@ -41,6 +43,7 @@ export default function RepositoryCard({
         <RepositoryCardInteractivePreviewLink
           repositoryDTO={repositoryDTO}
           pageContext={pageContext}
+          searchQuery={searchQuery}
         />
         <Card.Footer aria-label={title} title={title}>
           <Card.FooterIdentity>

--- a/src/components/repositoryCard/interactivePreviewLink/index.tsx
+++ b/src/components/repositoryCard/interactivePreviewLink/index.tsx
@@ -15,11 +15,13 @@ import RepositoryCardInteractiveTerminalPreview from '../interactiveTerminalPrev
 type RepositoryCardInteractivePreviewLinkProps = {
   repositoryDTO: RepositoryDTO;
   pageContext: PageContext;
+  searchQuery?: string;
 };
 
 export default function RepositoryCardInteractivePreviewLink({
   repositoryDTO,
   pageContext,
+  searchQuery,
 }: RepositoryCardInteractivePreviewLinkProps) {
   const repository = new Repository(repositoryDTO);
   const prioritizedBackground =
@@ -36,11 +38,19 @@ export default function RepositoryCardInteractivePreviewLink({
   const isDefaultVariant =
     selectedVariant.colorscheme === defaultVariant?.name &&
     selectedVariant.background === defaultVariant.backgrounds[0];
-  const href = isDefaultVariant
-    ? repository.route
-    : `${repository.route}?colorscheme=${encodeURIComponent(
-        selectedVariant.colorscheme,
-      )}&background=${encodeURIComponent(selectedVariant.background)}`;
+  const searchParams = new URLSearchParams();
+
+  if (!isDefaultVariant) {
+    searchParams.set('colorscheme', selectedVariant.colorscheme);
+    searchParams.set('background', selectedVariant.background);
+  }
+
+  if (searchQuery) {
+    searchParams.set('q', searchQuery);
+  }
+
+  const search = searchParams.toString();
+  const href = `${repository.route}${search ? `?${search}` : ''}`;
 
   const onVariantChange = useCallback(
     (variant: { colorscheme: string; background: Background }) => {


### PR DESCRIPTION
* preserve the active query in repository result links
* retain search state when selecting preview variants
* add regression coverage for both link forms