### PR TITLE
fix: restore the search query on escape

### DIFF
--- a/src/__tests__/components/exploreCommandInput.test.tsx
+++ b/src/__tests__/components/exploreCommandInput.test.tsx
@@ -1,6 +1,7 @@
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   render,
   screen,
@@ -832,6 +833,56 @@ describe('ExploreCommandInput', () => {
     });
     fireEvent.change(searchbox, { target: { value: '   ' } });
     fireEvent.submit(searchbox);
+
+    expect(navigation.replace).toHaveBeenCalledWith('/i/trending', {
+      scroll: false,
+    });
+  });
+
+  it('restores the submitted search query and blurs on Escape', () => {
+    navigation.searchParams = new URLSearchParams({ q: 'gruvbox' });
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    const searchbox = screen.getByRole<HTMLInputElement>('searchbox', {
+      name: 'Search repositories',
+    });
+    searchbox.focus();
+    fireEvent.change(searchbox, { target: { value: 'tokyo' } });
+    fireEvent.keyDown(searchbox, { key: 'Escape' });
+
+    expect(searchbox.value).toBe('gruvbox');
+    expect(document.activeElement).not.toBe(searchbox);
+    expect(navigation.replace).not.toHaveBeenCalled();
+  });
+
+  it('prevents the user agent from clearing the search input on Escape', () => {
+    navigation.searchParams = new URLSearchParams({ q: 'gruvbox' });
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    const searchbox = screen.getByRole('searchbox', {
+      name: 'Search repositories',
+    });
+    const escape = createEvent.keyDown(searchbox, { key: 'Escape' });
+    fireEvent(searchbox, escape);
+
+    expect(escape.defaultPrevented).toBe(true);
+  });
+
+  it('hands the keyboard back to shortcuts after Escape', () => {
+    navigation.pathname = '/i/old/b.dark';
+    navigation.searchParams = new URLSearchParams({ q: 'tokyo night' });
+    render(<ExploreCommandInput fallbackPageContext={fallbackPageContext} />);
+
+    const searchbox = screen.getByRole('searchbox', {
+      name: 'Search repositories',
+    });
+    searchbox.focus();
+    fireEvent.keyDown(searchbox, { key: 'r' });
+
+    expect(navigation.replace).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(searchbox, { key: 'Escape' });
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'r' });
 
     expect(navigation.replace).toHaveBeenCalledWith('/i/trending', {
       scroll: false,

--- a/src/components/exploreCommandInput/searchInput.tsx
+++ b/src/components/exploreCommandInput/searchInput.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, useEffect, useId, useRef, useState } from 'react';
+import {
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 
 import { RepositorySearchManifestClient } from '@/services/repositorySearchManifestClient';
 
@@ -61,6 +68,16 @@ export default function SearchInput() {
     inputRef.current?.focus();
   }
 
+  function restoreQuery(event: ReactKeyboardEvent<HTMLInputElement>) {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.value = query;
+    event.currentTarget.blur();
+  }
+
   function preloadManifest() {
     void RepositorySearchManifestClient.loadRepositorySearchManifest().catch(
       () => undefined,
@@ -115,6 +132,7 @@ export default function SearchInput() {
             type="search"
             onChange={preloadManifest}
             onFocus={preloadManifest}
+            onKeyDown={restoreQuery}
           />
           <button
             aria-label="Submit repository search"


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

pressing escape in the explore search input triggered the browser's built-in clear on `type="search"`. the field emptied while `?q=` stayed in the url, so the header, the results and the reset link all kept showing the old search next to an empty box. focus also stayed in the input, which leaves every single letter shortcut (`o`, `b`, `r`, `s`, `/`) dead.

escape now puts the committed query back and blurs, like `<Esc>` leaving insert mode. nothing is destroyed, the input can never disagree with the url, and the keyboard goes back to the page.

## Related issue

## QA Instructions

1. open an explore page with a search, e.g. `/i/trending?q=gruvbox`
2. type over the query, press escape
3. the input shows `gruvbox` again, focus leaves the input, url and results are untouched
4. press `r`, the search resets

checked in chromium. firefox and safari are worth a spot check, since the clear behavior comes from the browser.

## Added tests?

- [x] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
