### PR TITLE
fix: refresh cached repository data on each deployment

### DIFF
--- a/src/__tests__/services/repositoryCache.test.ts
+++ b/src/__tests__/services/repositoryCache.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheKeyParts = vi.hoisted(() => [] as string[][]);
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  unstable_cache: (fn: unknown, keyParts: string[]) => {
+    cacheKeyParts.push(keyParts);
+    return fn;
+  },
+}));
+
+describe('RepositoriesService repository cache', () => {
+  beforeEach(() => {
+    cacheKeyParts.length = 0;
+  });
+
+  it('keys every cache entry on the deployment so a rebuild starts clean', async () => {
+    vi.stubEnv('VERCEL_DEPLOYMENT_ID', 'dpl_test');
+    vi.resetModules();
+
+    await import('@/services/repositoriesServer');
+
+    expect(cacheKeyParts.flat()).toContain('dpl_test-repository-dto');
+    expect(
+      cacheKeyParts.flat().every(keyPart => keyPart.startsWith('dpl_test-')),
+    ).toBe(true);
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/services/repositoriesServer.ts
+++ b/src/services/repositoriesServer.ts
@@ -371,7 +371,7 @@ async function getRepositoryDTO(
   return rowToDTO(row, vimColorSchemes);
 }
 
-const BUILD_ID = process.env.NEXT_BUILD_ID ?? 'dev';
+const BUILD_ID = process.env.VERCEL_DEPLOYMENT_ID ?? 'dev';
 
 const cachedGetRepositoryCountQuery = unstable_cache(
   getRepositoryCount,


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

`BUILD_ID` keyed every `unstable_cache` entry on `NEXT_BUILD_ID`, which is set nowhere in the repo and nowhere in the Vercel project, so every deployment reused the same `dev-` prefix. Next persists the data cache across deployments, none of the six wrappers set `revalidate`, and nothing ever calls `revalidateTag('repositories')`, so entries never expired.

`getRepositoryDTO` filters on `has_dark = 1 OR has_light = 1`, so a repository looked up before its first successful generate correctly returns null. That null then stuck under its owner/name key permanently, and the page kept rendering "repository not found" long after the repo was indexed. The same permanence applied to positive entries, which were pinned from whenever they were first computed.

Keying on `VERCEL_DEPLOYMENT_ID` makes the daily rebuild the cache boundary, which is where content already refreshes. The worker calls the deploy hook after publishing, so the deployment that ships a repository's first generate is the same one that rotates the prefix. `VERCEL_GIT_COMMIT_SHA` would not work here, since the deploy hook rebuilds an unchanged commit. The deployment id does reach the build: the live HTML stamps assets with `?dpl=dpl_ENV8EKewcxdVFyWzujkVet3K4DEz`, matching the id `vercel inspect` reports for the current production deployment.

## Related issue

Closes #1393

## QA Instructions

1. `pnpm check` and `pnpm build` pass.
2. On this PR's preview deployment, open any repository page and confirm it renders. The preview environment has its own `DATABASE_URL`, so it may not carry `skylarmb/torchlight.nvim`.
3. After the next production deploy, open https://vimcolorschemes.com/r/skylarmb/torchlight.nvim and confirm it renders the repository rather than "repository not found". The mixed-case variants render today and should keep rendering.

## Added tests?

- [x] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no
