### PR TITLE
perf: cache the paginated repository query

### DIFF
--- a/src/__tests__/services/repositoryCache.test.ts
+++ b/src/__tests__/services/repositoryCache.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Constants } from '@/lib/constants';
+
 const cacheKeyParts = vi.hoisted(() => [] as string[][]);
 
 vi.mock('next/cache', () => ({
@@ -25,6 +27,19 @@ describe('RepositoriesService repository cache', () => {
     expect(
       cacheKeyParts.flat().every(keyPart => keyPart.startsWith('dpl_test-')),
     ).toBe(true);
+
+    vi.unstubAllEnvs();
+  });
+
+  it('caches the paginated query that serves load more', async () => {
+    vi.stubEnv('VERCEL_DEPLOYMENT_ID', 'dpl_test');
+    vi.resetModules();
+
+    await import('@/services/repositoriesServer');
+
+    expect(cacheKeyParts.flat()).toContain(
+      `dpl_test-repository-dto-page-${Constants.REPOSITORY_PAGE_SIZE}`,
+    );
 
     vi.unstubAllEnvs();
   });

--- a/src/services/repositoriesServer.ts
+++ b/src/services/repositoriesServer.ts
@@ -389,11 +389,18 @@ async function cachedGetRepositoryCount(filter: Filter): Promise<number> {
   return cachedGetRepositoryCountQuery(getRepositoryCountFilter(filter));
 }
 
-const cachedGetRepositoryDTOs = unstable_cache(
-  getRepositoryDTOs,
-  [`${BUILD_ID}-repository-dtos-${Constants.REPOSITORY_PAGE_SIZE}`],
+const cachedGetRepositoryDTOPage = unstable_cache(
+  getRepositoryDTOPage,
+  [`${BUILD_ID}-repository-dto-page-${Constants.REPOSITORY_PAGE_SIZE}`],
   { tags: ['repositories'] },
 );
+
+async function cachedGetRepositoryDTOs(
+  params: GetRepositoriesParams,
+): Promise<RepositoryDTO[]> {
+  const { repositories } = await cachedGetRepositoryDTOPage(params);
+  return repositories;
+}
 
 const cachedGetFeaturedRepositoryDTOs = unstable_cache(
   getFeaturedRepositoryDTOs,
@@ -435,7 +442,7 @@ async function cachedGetRepository(
 export const RepositoriesService = {
   getRepositoryCount: cachedGetRepositoryCount,
   getRepositories,
-  getRepositoryDTOPage,
+  getRepositoryDTOPage: cachedGetRepositoryDTOPage,
   getRepositoryDTOs: cachedGetRepositoryDTOs,
   getFeaturedRepositoryDTOs: cachedGetFeaturedRepositoryDTOs,
   getAllRepositories: cachedGetAllRepositories,


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

`/api/repositories` was the only db read not going through `unstable_cache`. every cdn miss re-ran the page query plus the colorscheme join for 60 repos. now it's cached like the rest, and `getRepositoryDTOs` reuses the same cached page.

## Related issue

## QA Instructions

open `/i/trending`, hit load more a few times, confirm the grid keeps appending and the count stays right. same on `/i/top/b.dark`.

## Added tests?

- [x] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no