### PR TITLE
fix: point sitemap repository urls at the generated routes

### DIFF
--- a/src/__tests__/app/sitemap.test.ts
+++ b/src/__tests__/app/sitemap.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import sitemap from '@/app/sitemap';
+
+const getAllRepositoryKeysMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/repositoriesServer', () => ({
+  RepositoriesService: {
+    getAllRepositoryKeys: getAllRepositoryKeysMock,
+  },
+}));
+
+describe('sitemap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APP_URL = 'https://vimcolorschemes.com';
+  });
+
+  it('lists repository urls with the lowercased route the pages are built at', async () => {
+    getAllRepositoryKeysMock.mockResolvedValue([
+      { ownerName: 'EdenEast', name: 'nightfox.nvim' },
+      { ownerName: 'morhetz', name: 'gruvbox' },
+    ]);
+
+    const entries = await sitemap();
+    const repositoryURLs = entries
+      .map(entry => entry.url)
+      .filter(url => url.includes('/r/'));
+
+    expect(repositoryURLs).toEqual([
+      'https://vimcolorschemes.com/r/edeneast/nightfox.nvim',
+      'https://vimcolorschemes.com/r/morhetz/gruvbox',
+    ]);
+  });
+});

--- a/src/app/[owner]/[name]/page.tsx
+++ b/src/app/[owner]/[name]/page.tsx
@@ -2,14 +2,16 @@ import { permanentRedirect } from 'next/navigation';
 
 import { RepositoriesService } from '@/services/repositoriesServer';
 
+import {
+  buildRepositoryPath,
+  buildRepositoryStaticParam,
+} from '@/helpers/repositoryRoute';
+
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const keys = await RepositoriesService.getAllRepositoryKeys();
-  return keys.map(k => ({
-    owner: k.ownerName.toLowerCase(),
-    name: k.name.toLowerCase(),
-  }));
+  return keys.map(k => buildRepositoryStaticParam(k.ownerName, k.name));
 }
 
 type LegacyRepositoryRouteProps = {
@@ -47,5 +49,5 @@ export default async function LegacyRepositoryRoute({
   const { owner, name } = await params;
   const search = getSearch(await searchParams);
 
-  permanentRedirect(`/r/${owner}/${name}${search}`);
+  permanentRedirect(`${buildRepositoryPath(owner, name)}${search}`);
 }

--- a/src/app/r/[owner]/[name]/page.tsx
+++ b/src/app/r/[owner]/[name]/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 
 import { RepositoriesService } from '@/services/repositoriesServer';
 
+import { buildRepositoryStaticParam } from '@/helpers/repositoryRoute';
+
 import RepositoryPageContent from '@/components/repositoryPageContent';
 
 import styles from './page.module.css';
@@ -10,10 +12,7 @@ export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const keys = await RepositoriesService.getAllRepositoryKeys();
-  return keys.map(k => ({
-    owner: k.ownerName.toLowerCase(),
-    name: k.name.toLowerCase(),
-  }));
+  return keys.map(k => buildRepositoryStaticParam(k.ownerName, k.name));
 }
 
 type RepositoryPageProps = { params: Promise<{ owner: string; name: string }> };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import { BackgroundFilter } from '@/lib/filter';
 import { SortOptions } from '@/lib/sort';
 
 import { FilterHelper } from '@/helpers/filter';
+import { buildRepositoryPath } from '@/helpers/repositoryRoute';
 
 export const revalidate = 86400;
 
@@ -30,7 +31,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const keys = await RepositoriesService.getAllRepositoryKeys();
   const repositoryURLs = keys.map(k => ({
-    url: `${process.env.APP_URL}/r/${k.ownerName}/${k.name}`,
+    url: `${process.env.APP_URL}${buildRepositoryPath(k.ownerName, k.name)}`,
     changeFrequency: 'weekly' as const,
     priority: 0.9,
   }));

--- a/src/helpers/repositoryRoute.ts
+++ b/src/helpers/repositoryRoute.ts
@@ -1,0 +1,7 @@
+export function buildRepositoryPath(ownerName: string, name: string): string {
+  return `/r/${ownerName}/${name}`.toLowerCase();
+}
+
+export function buildRepositoryStaticParam(ownerName: string, name: string) {
+  return { owner: ownerName.toLowerCase(), name: name.toLowerCase() };
+}

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -1,5 +1,7 @@
 import { Backgrounds, Background } from '@/lib/backgrounds';
 
+import { buildRepositoryPath } from '@/helpers/repositoryRoute';
+
 import { Colorscheme } from './colorscheme';
 import { RepositoryDTO } from './DTO/repository';
 import { Owner } from './owner';
@@ -47,7 +49,7 @@ class Repository {
    * @returns The route of the repository, used to navigate to the repository page.
    */
   get route(): string {
-    return `/r/${this.key}`.toLowerCase();
+    return buildRepositoryPath(this.owner.name, this.name);
   }
 
   /**


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

Repository pages are statically generated from lowercased owner and name, with `dynamicParams` disabled, so only lowercase paths resolve. The sitemap built its URLs from the raw database rows, which keep GitHub's original casing, so every repository with a capital letter was advertised to crawlers as a URL that 404s.

Route building now lives in a single helper used by the sitemap, the repository model, both `generateStaticParams`, and the legacy redirect, so the path and the params can no longer drift apart.

## Related issue

## QA Instructions

1. `pnpm dev`
2. Open `/sitemap.xml` and look for a repository with a capital letter in its owner or name, e.g. `EdenEast/nightfox.nvim`
3. The listed URL should be `/r/edeneast/nightfox.nvim`, and opening it should load the repository page instead of a 404

## Added tests?

- [x] unit tests
- [ ] E2E tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no