### PR TITLE
chore: add vercel ignore-build script for production, reobin, and dependabot builds

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# vercel ignored build step.
+# exit 1 = build, exit 0 = skip.
+# set the vercel dashboard command to: bash scripts/vercel-ignore-build.sh
+
+if [ "$VERCEL_ENV" = "production" ]; then exit 1; fi
+
+if [ -n "$VERCEL_GIT_PULL_REQUEST_ID" ]; then
+  if [ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" = "reobin" ]; then exit 1; fi
+  if [ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" = "dependabot[bot]" ]; then exit 1; fi
+  case "$VERCEL_GIT_COMMIT_REF" in dependabot/*) exit 1 ;; esac
+  exit 0
+fi
+
+exit 0


### PR DESCRIPTION
## Type of PR

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation update
- [ ] Tests

## Description

adds a versioned ignored build step script at scripts/vercel-ignore-build.sh. it builds production, reobin PRs, and dependabot PRs (author dependabot[bot] or branch dependabot/*), and cancels everything else by default. set the vercel dashboard ignored build step command to bash scripts/vercel-ignore-build.sh to stay under the 256-character limit.

## Related issue

none.

## QA Instructions

- confirm scripts/vercel-ignore-build.sh is executable.
- run the exit-code matrix: VERCEL_ENV=production builds (exit 1); reobin, dependabot[bot], and dependabot/* PRs build (exit 1); other-author PRs and bare preview branches cancel (exit 0).
- set the vercel dashboard ignored build step to bash scripts/vercel-ignore-build.sh and confirm a dependabot PR builds.

## Added tests?

- [ ] unit tests
- [ ] E2E tests
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added documentation?

- [ ] JSDoc
- [ ] docs.vimcolorschemes.com (`./docs`)
- [ ] README
- [x] no